### PR TITLE
docs: align README and guide parity for Sample and GameArena

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -1,10 +1,8 @@
 <div align="center">
 
-# 📐 Gage-Eval
+# 📐 GAGE: General AI evaluation and Gauge Engine
 
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue?logo=python&logoColor=white)](https://www.python.org/) [![Code Style](https://img.shields.io/badge/code%20style-google-blueviolet)](https://google.github.io/styleguide/pyguide.html) [![License](https://img.shields.io/badge/license-TBD-lightgrey)]() [![Status](https://img.shields.io/badge/Status-Alpha-orange)]()
-
-**新一代高性能、模块化大模型评测框架**
 
 [English](README.md) · **中文**
 
@@ -14,15 +12,19 @@
 
 ---
 
-**Gage-Eval** 是一个为生产环境设计的评估框架，旨在解决复杂评测链路中的**可扩展性**与**可复现性**问题。它通过 **Step-Chain**（步骤链）编排与 **RoleAdapter**（角色适配器）解耦，让评测像搭积木一样简单。
+**GAGE** 是面向大语言模型、多模态（全模态、机器人）模型、音频模型与扩散模型的统一可扩展评测框架。它是一套高性能评测引擎，强调极致执行效率、可扩展性与灵活性，为 AI 模型评测、Agent 基准与 Game Arena 对战评测提供统一底座。
 
-## ✨ 核心特性
+## ✨ 为什么选择 GAGE？
 
-- 🚀 **智能自适应执行引擎**：内置 **多种硬件环境感知**与**动态背压 (Backpressure)** 机制。在大规模评测中智能平衡吞吐量与显存占用，从根源上杜绝 OOM 风险。
-- 🧬 **继承式配置体系**：独创 **`Pipeline` -> `Run` 双层配置架构**，强调 **Benchmark 固化与版本化管理**。支持配置蒸馏 (Distill) 与运行时覆盖，大幅降低复杂任务的维护成本。
-- 📡 **企业级全链路观测**：超越静态日志，提供 **HTTP 实时遥测**与**缓冲区深度透视**。无缝集成生产级监控大盘，毫秒级定位性能瓶颈。
-- 🔌 **全能角色适配器**：统一抽象 **Agent / API / Docker 沙箱 / 本地模型**。内置连接池管理，让 SWE-bench 等复杂任务的编排像搭积木一样简单。
-- 🔗 **工业级流水线编排**：基于标准化 Sample 契约，自由编排（例如：`Support -> Inference -> Judge`）流程。打造如工业流水线般的高效数据处理链路。
+- 🚀 **极速评测引擎**：以性能为先，充分利用 GPU 与 CPU 资源，从单机测试到百万样本、多集群评测都能平滑扩展。
+
+- 🔗 **一体化评测接口**：以最少粘合代码评测任意数据集 × 任意模型。统一抽象数据集、模型、指标与运行时，快速接入新基准或新后端。
+
+- 🔌 **可扩展沙箱（Game 与 Agent）**：原生支持游戏评测、Agent 环境、GUI 交互沙箱与工具增强任务。全部能力运行在同一评测引擎中，统一评测 LLM、多模态模型与 Agent。
+
+- 🧩 **继承式扩展**：通过继承与覆写扩展已有基准，新增数据集、指标或评测逻辑无需修改核心框架或重写样板代码。
+
+- 📡 **企业级可观测性**：不止日志，提供运行阶段的实时指标与可视化能力，便于监控评测并快速定位性能瓶颈与失败原因。
 
 ## 🧭 设计概览
 

--- a/docs/guide/framework_overview_zh.md
+++ b/docs/guide/framework_overview_zh.md
@@ -11,7 +11,7 @@ gage-eval 是一个可扩展的大模型评测框架。它以 **Step 链路** �
 - 项目首页（English）：[`README.md`](../../README.md)
 - 项目首页（中文）：[`README_zh.md`](../../README_zh.md)
 - 测试体系：[`TESTING.md`](../../TESTING.md)
-- 示例配置：[`config/custom/`](../../config/custom/) 、[`config/builtin_templates/`](../../config/builtin_templates/)
+- 示例配置：[`config/custom/`](../../config/custom/)、[`config/builtin_templates/`](../../config/builtin_templates/)、[`config/run_configs/`](../../config/run_configs/)
 - 扩展开发：[`support_cli_zh.md`](support_cli_zh.md)（support 模块指南，实验性，后续由 gage-client 取代）
 - Sample 契约：[`sample_zh.md`](sample_zh.md)（标准化 Sample 设计）
 - Game Arena：[`game_arena_zh.md`](game_arena_zh.md)（对战评测模块）


### PR DESCRIPTION
- Synced README_zh.md with the English README (title, intro, and “Why GAGE” section).
- Completed guide parity by adding missing run_configs reference in framework_overview_zh.md.
- Filled gaps in sample.md with runtime result examples, predict_result write-back excerpt, and agent flow diagram.
- Maintained consistent structure and links across bilingual docs.