### PR TITLE
feat(inverse_ifeval): add dataset config preprocessor and metrics

### DIFF
--- a/config/custom/inverse_ifeval/inverse_ifeval_qwen_omni_suite.yaml
+++ b/config/custom/inverse_ifeval/inverse_ifeval_qwen_omni_suite.yaml
@@ -1,0 +1,154 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+metadata:
+  name: inverse_ifeval_qwen_omni_suite
+  description: Evaluate Inverse IFEval with a local DUT model and an LLM judge.
+
+custom:
+  steps:
+    - step: inference
+      adapter_id: dut_qwen3_omni
+    - step: judge
+      adapter_id: judge_inverse_ifeval
+    - step: auto_eval
+
+prompts:
+  - prompt_id: inverse_ifeval_judge_prompt
+    renderer: jinja_delimited_chat
+    template: |
+      {% set meta = sample.get("metadata", {}) %}
+      {{ meta.get("judge_system_prompt") or "You are a strict instruction-following grader. Return only a single score between 0 and 1." }}
+      ---
+      {% set judge_template = meta.get("judge_prompt_template") or "<Question>: {prompt}\n<Reference Answer>: {response_reference}\n<Model Answer>: {response}\nJudge whether the model answer follows the instruction. Return only 0 or 1." %}
+      {% set prompt_text = meta.get("prompt_text") or "" %}
+      {% set reference_text = meta.get("response_reference") or sample.get("label") or "" %}
+      {% set model_answer = payload.get("model_output", {}).get("answer") or "" %}
+      {{ judge_template
+          | replace("{prompt}", prompt_text | string)
+          | replace("{response_reference}", reference_text | string)
+          | replace("{response}", model_answer | string)
+      }}
+
+datasets:
+  - dataset_id: inverse_ifeval_test
+    hub: huggingface
+    hub_params:
+      hub_id: m-a-p/Inverse_IFEval
+      split: train
+      revision: main
+    loader: hf_hub
+    params:
+      preprocess: inverse_ifeval_preprocessor
+      streaming: false
+
+backends:
+  - backend_id: qwen25_omni_backend
+    type: litellm
+    config:
+      provider: openai
+      api_base: ${INVERSE_IFEVAL_API_BASE:-http://127.0.0.1:1234/v1}
+      api_key: ${INVERSE_IFEVAL_API_KEY:-dummy}
+      model: ${QWEN25_OMNI_MODEL:-Qwen/Qwen2.5-Omni-7B}
+      generation_parameters:
+        max_new_tokens: 512
+        temperature: 0.0
+      streaming: false
+
+  - backend_id: qwen3_omni_backend
+    type: litellm
+    config:
+      provider: openai
+      api_base: ${INVERSE_IFEVAL_API_BASE:-http://127.0.0.1:1234/v1}
+      api_key: ${INVERSE_IFEVAL_API_KEY:-dummy}
+      model: ${QWEN3_OMNI_MODEL:-qwen3-omni-flash}
+      generation_parameters:
+        max_new_tokens: 512
+        temperature: 0.0
+      streaming: false
+
+  - backend_id: inverse_ifeval_judge_backend
+    type: litellm
+    config:
+      provider: openai
+      api_base: ${INVERSE_IFEVAL_JUDGE_API_BASE:-http://127.0.0.1:1234/v1}
+      api_key: ${INVERSE_IFEVAL_JUDGE_API_KEY:-dummy}
+      model: ${INVERSE_IFEVAL_JUDGE_MODEL:-qwen3-omni-flash}
+      generation_parameters:
+        max_new_tokens: 128
+        temperature: 0.0
+      streaming: false
+
+  - backend_id: qwen3_vl_30b_a3b_backend
+    type: litellm
+    config:
+      provider: openai
+      api_base: ${INVERSE_IFEVAL_API_BASE:-http://127.0.0.1:1234/v1}
+      api_key: ${INVERSE_IFEVAL_API_KEY:-dummy}
+      model: ${QWEN3_VL_30B_A3B_MODEL:-Qwen/Qwen3-VL-30B-A3B}
+      generation_parameters:
+        max_new_tokens: 512
+        temperature: 0.0
+      streaming: false
+
+role_adapters:
+  - adapter_id: dut_qwen25_omni
+    role_type: dut_model
+    backend_id: qwen25_omni_backend
+    capabilities:
+      - chat_completion
+
+  - adapter_id: dut_qwen3_omni
+    role_type: dut_model
+    backend_id: qwen3_omni_backend
+    capabilities:
+      - chat_completion
+
+  - adapter_id: judge_inverse_ifeval
+    role_type: judge_model
+    backend_id: inverse_ifeval_judge_backend
+    prompt_id: inverse_ifeval_judge_prompt
+    capabilities:
+      - chat_completion
+
+  - adapter_id: dut_qwen3_vl_30b_a3b
+    role_type: dut_model
+    backend_id: qwen3_vl_30b_a3b_backend
+    capabilities:
+      - chat_completion
+
+metrics:
+  - metric_id: inverse_ifeval_judge_pass_rate
+    implementation: inverse_ifeval_judge_pass_rate
+    params:
+      threshold: 0.5
+      fallback: 0.0
+  - metric_id: latency
+    implementation: latency
+
+tasks:
+  - task_id: inverse_ifeval_qwen25_omni
+    dataset_id: inverse_ifeval_test
+    steps:
+      - step: inference
+        adapter_id: dut_qwen25_omni
+      - step: judge
+        adapter_id: judge_inverse_ifeval
+      - step: auto_eval
+
+  - task_id: inverse_ifeval_qwen3_omni
+    dataset_id: inverse_ifeval_test
+    steps:
+      - step: inference
+        adapter_id: dut_qwen3_omni
+      - step: judge
+        adapter_id: judge_inverse_ifeval
+      - step: auto_eval
+
+  - task_id: inverse_ifeval_qwen3_vl_30b_a3b
+    dataset_id: inverse_ifeval_test
+    steps:
+      - step: inference
+        adapter_id: dut_qwen3_vl_30b_a3b
+      - step: judge
+        adapter_id: judge_inverse_ifeval
+      - step: auto_eval

--- a/src/gage_eval/assets/datasets/preprocessors/builtin.py
+++ b/src/gage_eval/assets/datasets/preprocessors/builtin.py
@@ -100,6 +100,7 @@ from gage_eval.assets.datasets.preprocessors.mrcr.mrcr_converter import MRCRConv
 
 # benchmark MMSU (audio)
 from gage_eval.assets.datasets.preprocessors.mmsu.mmsu_converter import MMSUConverter
+from gage_eval.assets.datasets.preprocessors.inverse_ifeval_preprocessor import InverseIFEvalPreprocessor
 
 @registry.asset(
     "dataset_preprocessors",
@@ -466,4 +467,13 @@ class MRCRPreprocessor(MRCRConverter):
 class MMSUPreprocessor(MMSUConverter):
     pass
 
+
+@registry.asset(
+    "dataset_preprocessors",
+    "inverse_ifeval_preprocessor",
+    desc="Inverse IFEval preprocessing logic",
+    tags=("instruction_following", "ifeval", "inverse"),
+)
+class InverseIFEvalPreprocessorProvider(InverseIFEvalPreprocessor):
+    pass
 

--- a/src/gage_eval/assets/datasets/preprocessors/inverse_ifeval_preprocessor.py
+++ b/src/gage_eval/assets/datasets/preprocessors/inverse_ifeval_preprocessor.py
@@ -1,0 +1,197 @@
+"""Inverse IFEval dataset preprocessor."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, Iterable, Sequence
+
+from gage_eval.assets.datasets.preprocessors.base import BasePreprocessor
+from gage_eval.assets.datasets.sample import (
+    SCHEMA_VERSION,
+    Message,
+    MessageContent,
+    Sample,
+)
+
+
+class InverseIFEvalPreprocessor(BasePreprocessor):
+    """Converts Inverse IFEval records into the standard Sample schema.
+
+    The preprocessor is intentionally tolerant to minor schema variations so that
+    the same implementation can work across hub revisions.
+    """
+
+    def to_sample(
+        self,
+        record: Dict[str, Any],
+        *,
+        schema_version: str = SCHEMA_VERSION,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> Sample:
+        """Converts a raw Inverse IFEval row to a Sample.
+
+        Args:
+            record: Raw row from the dataset loader.
+            schema_version: Sample schema version.
+            system_prompt: Optional system instruction prepended to messages.
+            **kwargs: Reserved for forward compatibility.
+
+        Returns:
+            A normalized Sample object for downstream inference and metrics.
+        """
+
+        # STEP 1: Resolve primary fields with conservative fallback order.
+        prompt_text = self._resolve_prompt(record)
+        sample_id = self._resolve_sample_id(record, prompt_text)
+        references = self._resolve_references(record)
+        response_reference = self._resolve_response_reference(record, references)
+
+        constraints = self._as_list(record.get("constraints"))
+        instruction_ids = self._as_list(record.get("instruction_id_list") or record.get("instruction_ids"))
+        instruction_kwargs = self._as_dict(record.get("kwargs") or record.get("instruction_kwargs"))
+        raw_schema_fragment = self._resolve_schema_fragment(record)
+
+        # STEP 2: Build canonical chat messages.
+        messages: list[Message] = []
+        if system_prompt:
+            messages.append(
+                Message(
+                    role="system",
+                    content=[MessageContent(type="text", text=system_prompt.strip())],
+                )
+            )
+        messages.append(
+            Message(
+                role="user",
+                content=[MessageContent(type="text", text=prompt_text)],
+            )
+        )
+
+        # STEP 3: Build metadata payload used by downstream metrics/judge prompts.
+        metadata: Dict[str, Any] = {
+            "prompt_text": prompt_text,
+            "response_reference": response_reference,
+            "constraints": constraints,
+            "instruction_id_list": instruction_ids,
+            "kwargs": instruction_kwargs,
+            "raw_schema_fragment": raw_schema_fragment,
+        }
+        for key in (
+            "task_id",
+            "subset",
+            "category",
+            "source",
+            "difficulty",
+            "split",
+            "sample_id",
+            "id",
+            "language",
+            "judge_prompt_template",
+            "judge_system_prompt",
+        ):
+            if key in record and record.get(key) is not None:
+                metadata[key] = record.get(key)
+
+        label = references[0] if references else None
+        return Sample(
+            id=sample_id,
+            schema_version=schema_version,
+            messages=messages,
+            references=references,
+            label=label,
+            metadata=metadata,
+        )
+
+    def _resolve_prompt(self, record: Dict[str, Any]) -> str:
+        """Resolves prompt text from known IFEval field aliases."""
+
+        for key in ("prompt", "question", "input", "instruction", "text"):
+            value = record.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _resolve_sample_id(self, record: Dict[str, Any], prompt_text: str) -> str:
+        """Builds a stable sample id from explicit ids or content hash."""
+
+        explicit_id = record.get("id") or record.get("sample_id")
+        if explicit_id is not None and str(explicit_id).strip():
+            return str(explicit_id).strip()
+
+        hash_payload = {
+            "prompt": prompt_text,
+            "constraints": record.get("constraints"),
+            "instruction_id_list": record.get("instruction_id_list") or record.get("instruction_ids"),
+            "kwargs": record.get("kwargs") or record.get("instruction_kwargs"),
+        }
+        encoded = json.dumps(hash_payload, sort_keys=True, ensure_ascii=True, default=str)
+        digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+        return f"inverse_ifeval_{digest[:16]}"
+
+    def _resolve_references(self, record: Dict[str, Any]) -> list[str]:
+        """Extracts references/targets when present; otherwise returns empty list."""
+
+        for key in ("references", "reference", "targets", "target", "answers", "answer", "label"):
+            if key not in record:
+                continue
+            values = self._as_list(record.get(key))
+            cleaned = [str(item).strip() for item in values if str(item).strip()]
+            if cleaned:
+                return cleaned
+        response_reference = record.get("response_reference")
+        if isinstance(response_reference, str) and response_reference.strip():
+            return [response_reference.strip()]
+        return []
+
+    def _resolve_response_reference(self, record: Dict[str, Any], references: Sequence[str]) -> str:
+        """Resolves canonical response reference text for judge prompts."""
+
+        value = record.get("response_reference")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if references:
+            first = str(references[0]).strip()
+            if first:
+                return first
+        return ""
+
+    def _resolve_schema_fragment(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        """Extracts an optional schema-like fragment for debugging/traceability."""
+
+        for key in ("schema", "schema_fragment", "rule_schema", "constraints_schema"):
+            value = record.get(key)
+            if isinstance(value, dict):
+                return dict(value)
+        return {}
+
+    @staticmethod
+    def _as_list(value: Any) -> list[Any]:
+        """Converts unknown inputs into a list with best-effort normalization."""
+
+        if value is None:
+            return []
+        if isinstance(value, dict):
+            return [dict(value)]
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, str):
+            normalized = value.strip()
+            return [normalized] if normalized else []
+        if isinstance(value, Iterable):
+            return list(value)
+        return [value]
+
+    @staticmethod
+    def _as_dict(value: Any) -> Dict[str, Any]:
+        """Returns a shallow dict for kwargs-like values."""
+
+        if isinstance(value, dict):
+            return dict(value)
+        return {}
+
+
+__all__ = ["InverseIFEvalPreprocessor"]

--- a/src/gage_eval/metrics/builtin/__init__.py
+++ b/src/gage_eval/metrics/builtin/__init__.py
@@ -42,6 +42,10 @@ from gage_eval.metrics.builtin.simpleqa_verified import (
 from gage_eval.metrics.builtin.arcagi2 import ARCAGI2AccuracyMetric
 from gage_eval.metrics.builtin.charxiv import CharXivReasoningMatchMetric
 from gage_eval.metrics.builtin.screenspot_pro import ScreenSpotPointInBboxMetric
+from gage_eval.metrics.builtin.inverse_ifeval import (
+    InverseIFEvalJudgePassRateMetric,
+    InverseIFEvalPassRateMetric,
+)
 
 __all__ = [
     "ARCAGI2AccuracyMetric",
@@ -76,4 +80,6 @@ __all__ = [
     "SimpleQAVerifiedJudgeAccuracyMetric",
     "ScreenSpotPointInBboxMetric",
     "CharXivReasoningMatchMetric",
+    "InverseIFEvalJudgePassRateMetric",
+    "InverseIFEvalPassRateMetric",
 ]

--- a/src/gage_eval/metrics/builtin/inverse_ifeval.py
+++ b/src/gage_eval/metrics/builtin/inverse_ifeval.py
@@ -1,0 +1,430 @@
+"""Rule-based metric for Inverse IFEval instruction compliance."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+from gage_eval.metrics.base import MetricContext, MetricResult, SimpleMetric
+from gage_eval.registry import registry
+
+
+@registry.asset(
+    "metrics",
+    "inverse_ifeval_pass_rate",
+    desc="Inverse IFEval rule-based pass-rate metric",
+    tags=("instruction_following", "ifeval", "inverse"),
+    default_aggregation="mean",
+)
+class InverseIFEvalPassRateMetric(SimpleMetric):
+    """Computes pass rate from explicit constraints or instruction identifiers."""
+
+    value_key = "pass_rate"
+
+    def compute(self, context: MetricContext) -> MetricResult:
+        """Evaluates the model answer against instruction/constraint rules.
+
+        Args:
+            context: Runtime metric context carrying sample and model outputs.
+
+        Returns:
+            MetricResult with `pass_rate` and `passed` values and diagnostics.
+        """
+
+        # STEP 1: Resolve normalized answer text and rule payload.
+        answer = self._normalize_text(self._resolve_answer(context))
+        sample = dict(context.sample or {})
+        metadata = dict(sample.get("metadata") or {})
+
+        constraints = self._as_list(metadata.get("constraints"))
+        instruction_ids = self._as_list(metadata.get("instruction_id_list") or metadata.get("instruction_ids"))
+        instruction_kwargs = self._as_dict(metadata.get("kwargs") or metadata.get("instruction_kwargs"))
+
+        # STEP 2: Build evaluable rule list (constraints take precedence).
+        if constraints:
+            rules = constraints
+            rule_origin = "constraints"
+        else:
+            rules = self._materialize_rules_from_instruction_ids(instruction_ids, instruction_kwargs)
+            rule_origin = "instruction_id_list"
+
+        # STEP 3: Evaluate each rule with strict handling for unsupported ones.
+        failed_rule_ids: list[str] = []
+        unsupported_rule_ids: list[str] = []
+        passed_rules = 0
+        total_rules = len(rules)
+
+        for idx, raw_rule in enumerate(rules):
+            rule = self._normalize_rule(raw_rule, idx)
+            rule_id = rule["rule_id"]
+            verdict = self._evaluate_rule(answer, rule)
+            if verdict == "pass":
+                passed_rules += 1
+                continue
+            if verdict == "unsupported":
+                unsupported_rule_ids.append(rule_id)
+            failed_rule_ids.append(rule_id)
+
+        pass_rate = float(passed_rules / total_rules) if total_rules > 0 else 0.0
+        passed = 1.0 if total_rules > 0 and passed_rules == total_rules else 0.0
+
+        metric_metadata = {
+            "rule_origin": rule_origin,
+            "total_rules": total_rules,
+            "passed_rules": passed_rules,
+            "failed_rule_ids": failed_rule_ids,
+            "unsupported_rule_ids": unsupported_rule_ids,
+        }
+        return MetricResult(
+            sample_id=context.sample_id,
+            values={"pass_rate": pass_rate, "passed": passed},
+            metadata=metric_metadata,
+        )
+
+    def _resolve_answer(self, context: MetricContext) -> str:
+        """Finds answer text from model_output and sample-level fallbacks."""
+
+        model_output = dict(context.model_output or {})
+        answer = model_output.get("answer")
+        if isinstance(answer, str) and answer.strip():
+            return answer
+
+        sample = dict(context.sample or {})
+        predict_result = sample.get("predict_result")
+        if isinstance(predict_result, list) and predict_result:
+            first = predict_result[0]
+            if isinstance(first, Mapping):
+                message = first.get("message")
+                if isinstance(message, Mapping):
+                    content = message.get("content")
+                    if isinstance(content, list) and content:
+                        fragment = content[0]
+                        if isinstance(fragment, Mapping):
+                            text = fragment.get("text")
+                            if isinstance(text, str):
+                                return text
+        return ""
+
+    def _normalize_rule(self, raw_rule: Any, index: int) -> Dict[str, Any]:
+        """Converts free-form rule payloads into a canonical structure."""
+
+        if isinstance(raw_rule, str):
+            return {
+                "rule_id": f"rule_{index}",
+                "type": "must_contain",
+                "value": raw_rule,
+            }
+
+        if not isinstance(raw_rule, dict):
+            return {
+                "rule_id": f"rule_{index}",
+                "type": "unsupported",
+            }
+
+        rule = dict(raw_rule)
+        rule.setdefault("rule_id", str(rule.get("id") or rule.get("instruction_id") or f"rule_{index}"))
+        rule_type = (
+            rule.get("type")
+            or rule.get("op")
+            or rule.get("constraint_type")
+            or rule.get("name")
+        )
+        rule["type"] = str(rule_type).strip().lower() if rule_type else "unsupported"
+        return rule
+
+    def _evaluate_rule(self, answer: str, rule: Dict[str, Any]) -> str:
+        """Evaluates a single normalized rule against the answer.
+
+        Returns:
+            "pass", "fail", or "unsupported".
+        """
+
+        rule_type = str(rule.get("type") or "").lower()
+
+        if rule_type in {"must_contain", "contains", "include"}:
+            needle = self._normalize_text(rule.get("value") or rule.get("needle") or "")
+            if not needle:
+                return "fail"
+            return "pass" if needle in answer else "fail"
+
+        if rule_type in {"must_not_contain", "not_contains", "exclude"}:
+            needle = self._normalize_text(rule.get("value") or rule.get("needle") or "")
+            if not needle:
+                return "fail"
+            return "pass" if needle not in answer else "fail"
+
+        if rule_type in {"regex_match", "match_regex", "pattern"}:
+            pattern = rule.get("pattern") or rule.get("value")
+            if not isinstance(pattern, str) or not pattern:
+                return "fail"
+            flags = re.IGNORECASE if not self._case_sensitive() else 0
+            return "pass" if re.search(pattern, answer, flags=flags) else "fail"
+
+        if rule_type in {"max_length", "length_max"}:
+            threshold = self._to_int(rule.get("value") or rule.get("max"))
+            if threshold is None:
+                return "fail"
+            return "pass" if len(answer) <= threshold else "fail"
+
+        if rule_type in {"min_length", "length_min"}:
+            threshold = self._to_int(rule.get("value") or rule.get("min"))
+            if threshold is None:
+                return "fail"
+            return "pass" if len(answer) >= threshold else "fail"
+
+        if rule_type in {"equals", "exact_match"}:
+            target = self._normalize_text(rule.get("value") or rule.get("target") or "")
+            if not target:
+                return "fail"
+            return "pass" if answer == target else "fail"
+
+        return "unsupported"
+
+    def _materialize_rules_from_instruction_ids(
+        self,
+        instruction_ids: Sequence[Any],
+        instruction_kwargs: Mapping[str, Any],
+    ) -> List[Dict[str, Any]]:
+        """Builds canonical rules from instruction ids and kwargs payload."""
+
+        rules: list[Dict[str, Any]] = []
+        for idx, raw_id in enumerate(instruction_ids):
+            if raw_id is None:
+                continue
+            instruction_id = str(raw_id).strip().lower()
+            if not instruction_id:
+                continue
+
+            # Keep handlers intentionally small and explicit to stay diagnosable.
+            if instruction_id in {"contains", "must_contain"}:
+                needle = instruction_kwargs.get(instruction_id) or instruction_kwargs.get("contains")
+                rules.append({"rule_id": f"inst_{idx}_{instruction_id}", "type": "must_contain", "value": needle})
+            elif instruction_id in {"not_contains", "must_not_contain"}:
+                needle = instruction_kwargs.get(instruction_id) or instruction_kwargs.get("not_contains")
+                rules.append({"rule_id": f"inst_{idx}_{instruction_id}", "type": "must_not_contain", "value": needle})
+            elif instruction_id in {"regex", "regex_match"}:
+                pattern = instruction_kwargs.get(instruction_id) or instruction_kwargs.get("regex")
+                rules.append({"rule_id": f"inst_{idx}_{instruction_id}", "type": "regex_match", "pattern": pattern})
+            elif instruction_id in {"max_length", "min_length", "exact_match", "equals"}:
+                value = instruction_kwargs.get(instruction_id)
+                rules.append({"rule_id": f"inst_{idx}_{instruction_id}", "type": instruction_id, "value": value})
+            else:
+                rules.append({"rule_id": f"inst_{idx}_{instruction_id}", "type": "unsupported"})
+        return rules
+
+    def _normalize_text(self, value: Any) -> str:
+        """Normalizes text deterministically with configurable case policy."""
+
+        text = "" if value is None else str(value)
+        if bool(self.args.get("strip_whitespace", True)):
+            text = text.strip()
+        if bool(self.args.get("collapse_whitespace", True)):
+            text = re.sub(r"\s+", " ", text)
+        if not self._case_sensitive():
+            text = text.lower()
+        return text
+
+    def _case_sensitive(self) -> bool:
+        """Returns case-sensitivity preference."""
+
+        return bool(self.args.get("case_sensitive", False))
+
+    @staticmethod
+    def _to_int(value: Any) -> int | None:
+        """Converts values to int when possible."""
+
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _as_list(value: Any) -> list[Any]:
+        """Normalizes values to list for rule payload extraction."""
+
+        if value is None:
+            return []
+        if isinstance(value, dict):
+            return [dict(value)]
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        if isinstance(value, str):
+            stripped = value.strip()
+            return [stripped] if stripped else []
+        if isinstance(value, Iterable):
+            return list(value)
+        return [value]
+
+    @staticmethod
+    def _as_dict(value: Any) -> Dict[str, Any]:
+        """Normalizes kwargs-like payloads to dictionary."""
+
+        if isinstance(value, dict):
+            return dict(value)
+        return {}
+
+
+@registry.asset(
+    "metrics",
+    "inverse_ifeval_judge_pass_rate",
+    desc="Inverse IFEval pass-rate metric using judge model outputs",
+    tags=("instruction_following", "ifeval", "inverse", "judge"),
+    default_aggregation="mean",
+)
+class InverseIFEvalJudgePassRateMetric(SimpleMetric):
+    """Computes pass rate from judge model verdicts."""
+
+    value_key = "pass_rate"
+
+    def compute(self, context: MetricContext) -> MetricResult:
+        """Converts judge output payload into a stable binary pass signal.
+
+        Args:
+            context: Runtime metric context carrying judge outputs.
+
+        Returns:
+            MetricResult with normalized pass-rate values and parsing metadata.
+        """
+
+        # STEP 1: Resolve threshold/fallback and normalize judge output payload.
+        threshold = float(self.args.get("threshold", 0.5))
+        fallback = float(self.args.get("fallback", 0.0))
+        judge_output = dict(context.judge_output or {})
+
+        # STEP 2: Parse score signal from judge payload using resilient fallbacks.
+        score, source, raw_value = self._extract_score(judge_output, fallback=fallback)
+        score = max(0.0, min(1.0, float(score)))
+        passed = 1.0 if score >= threshold else 0.0
+
+        # STEP 3: Emit metric values and diagnostics for traceability.
+        return MetricResult(
+            sample_id=context.sample_id,
+            values={"pass_rate": passed, "passed": passed},
+            metadata={
+                "judge_score": score,
+                "judge_threshold": threshold,
+                "judge_source": source,
+                "judge_raw_value": raw_value,
+            },
+        )
+
+    def _extract_score(self, judge_output: Mapping[str, Any], *, fallback: float) -> tuple[float, str, Any]:
+        """Extracts a normalized score from judge output mappings."""
+
+        if not judge_output:
+            return fallback, "fallback.empty_judge_output", None
+
+        for key in ("score", "pass_rate", "passed", "pass", "result", "verdict", "label", "answer"):
+            if key not in judge_output:
+                continue
+            parsed = self._coerce_score(judge_output.get(key))
+            if parsed is not None:
+                return parsed, f"judge_output.{key}", judge_output.get(key)
+
+        return fallback, "fallback.unrecognized_judge_output", dict(judge_output)
+
+    def _coerce_score(self, value: Any) -> float | None:
+        """Coerces heterogeneous judge values into a [0, 1] score."""
+
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+        if isinstance(value, (int, float)):
+            return self._normalize_numeric_score(float(value))
+        if isinstance(value, Mapping):
+            for key in ("score", "pass_rate", "passed", "pass", "result", "verdict", "label", "answer"):
+                if key in value:
+                    parsed = self._coerce_score(value.get(key))
+                    if parsed is not None:
+                        return parsed
+            return None
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+
+            if text.startswith("{") and text.endswith("}"):
+                try:
+                    parsed_json = json.loads(text)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    parsed_json = None
+                if isinstance(parsed_json, Mapping):
+                    parsed = self._coerce_score(parsed_json)
+                    if parsed is not None:
+                        return parsed
+
+            normalized = self._normalize_token(text)
+            if normalized in {
+                "1",
+                "true",
+                "yes",
+                "y",
+                "pass",
+                "passed",
+                "correct",
+                "compliant",
+                "符合",
+                "通过",
+                "是",
+            }:
+                return 1.0
+            if normalized in {
+                "0",
+                "false",
+                "no",
+                "n",
+                "fail",
+                "failed",
+                "incorrect",
+                "non_compliant",
+                "不符合",
+                "未通过",
+                "否",
+            }:
+                return 0.0
+
+            number = self._extract_first_number(text)
+            if number is not None:
+                return self._normalize_numeric_score(number)
+
+        return None
+
+    @staticmethod
+    def _normalize_token(text: str) -> str:
+        """Normalizes token-like verdict strings."""
+
+        token = text.strip().lower()
+        token = token.replace("-", "_")
+        token = re.sub(r"\s+", "_", token)
+        return token
+
+    @staticmethod
+    def _extract_first_number(text: str) -> float | None:
+        """Extracts the first numeric token from a string."""
+
+        match = re.search(r"[-+]?\d*\.?\d+", text)
+        if not match:
+            return None
+        try:
+            return float(match.group(0))
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _normalize_numeric_score(value: float) -> float:
+        """Normalizes raw numeric scores into [0, 1]."""
+
+        if value < 0:
+            return 0.0
+        if value <= 1:
+            return value
+        if value <= 100:
+            return value / 100.0
+        return 1.0
+
+
+__all__ = ["InverseIFEvalPassRateMetric", "InverseIFEvalJudgePassRateMetric"]

--- a/tests/config/test_inverse_ifeval_config.py
+++ b/tests/config/test_inverse_ifeval_config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gage_eval.config.pipeline_config import PipelineConfig
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_qwen_omni_suite_config_parses() -> None:
+    config_path = (
+        Path(__file__).resolve().parents[2]
+        / "config"
+        / "custom"
+        / "inverse_ifeval"
+        / "inverse_ifeval_qwen_omni_suite.yaml"
+    )
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config = PipelineConfig.from_dict(payload)
+
+    assert config.metadata.get("name") == "inverse_ifeval_qwen_omni_suite"
+    assert len(config.datasets) == 1
+
+    dataset = config.datasets[0]
+    assert dataset.dataset_id == "inverse_ifeval_test"
+    assert dataset.hub == "huggingface"
+    assert dataset.hub_params.get("hub_id") == "m-a-p/Inverse_IFEval"
+    assert dataset.hub_params.get("split") == "train"
+    assert dataset.hub_params.get("revision") == "main"
+    assert dataset.params.get("preprocess") == "inverse_ifeval_preprocessor"
+
+    backend_ids = {backend.backend_id for backend in config.backends}
+    assert "qwen3_omni_backend" in backend_ids
+    assert "inverse_ifeval_judge_backend" in backend_ids
+
+    adapter_to_backend = {adapter.adapter_id: adapter.backend_id for adapter in config.role_adapters}
+    assert adapter_to_backend["dut_qwen3_omni"] == "qwen3_omni_backend"
+    assert adapter_to_backend["judge_inverse_ifeval"] == "inverse_ifeval_judge_backend"
+
+    metric_ids = {metric.metric_id for metric in config.metrics}
+    assert "inverse_ifeval_judge_pass_rate" in metric_ids
+    assert "latency" in metric_ids
+
+    task_map = {task.task_id: task for task in config.tasks}
+    assert "inverse_ifeval_qwen3_omni" in task_map
+    assert all(task.dataset_id == "inverse_ifeval_test" for task in task_map.values())
+    task_steps = [step.step_type for step in task_map["inverse_ifeval_qwen3_omni"].steps]
+    assert task_steps == ["inference", "judge", "auto_eval"]

--- a/tests/metrics/test_inverse_ifeval_metric.py
+++ b/tests/metrics/test_inverse_ifeval_metric.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import pytest
+
+from gage_eval.config.pipeline_config import MetricSpec
+from gage_eval.metrics.base import MetricContext
+from gage_eval.metrics.builtin.inverse_ifeval import (
+    InverseIFEvalJudgePassRateMetric,
+    InverseIFEvalPassRateMetric,
+)
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_metric_explicit_constraints_path() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_pass_rate",
+        implementation="inverse_ifeval_pass_rate",
+        params={},
+    )
+    metric = InverseIFEvalPassRateMetric(spec)
+    context = MetricContext(
+        sample_id="s1",
+        sample={
+            "metadata": {
+                "constraints": [
+                    {"id": "r1", "type": "must_contain", "value": "hello"},
+                    {"id": "r2", "type": "must_not_contain", "value": "forbidden"},
+                ]
+            }
+        },
+        model_output={"answer": "Hello world"},
+        judge_output={},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 1.0
+    assert result.values["passed"] == 1.0
+    assert result.metadata["total_rules"] == 2
+    assert result.metadata["failed_rule_ids"] == []
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_metric_instruction_id_path() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_pass_rate",
+        implementation="inverse_ifeval_pass_rate",
+        params={},
+    )
+    metric = InverseIFEvalPassRateMetric(spec)
+    context = MetricContext(
+        sample_id="s2",
+        sample={
+            "metadata": {
+                "instruction_id_list": ["contains", "max_length"],
+                "kwargs": {"contains": "ok", "max_length": 20},
+            }
+        },
+        model_output={"answer": "ok"},
+        judge_output={},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 1.0
+    assert result.values["passed"] == 1.0
+    assert result.metadata["rule_origin"] == "instruction_id_list"
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_metric_unsupported_rule_is_failed() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_pass_rate",
+        implementation="inverse_ifeval_pass_rate",
+        params={},
+    )
+    metric = InverseIFEvalPassRateMetric(spec)
+    context = MetricContext(
+        sample_id="s3",
+        sample={
+            "metadata": {
+                "constraints": [
+                    {"id": "u1", "type": "some_unsupported_rule"},
+                ]
+            }
+        },
+        model_output={"answer": "anything"},
+        judge_output={},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 0.0
+    assert result.values["passed"] == 0.0
+    assert result.metadata["unsupported_rule_ids"] == ["u1"]
+    assert result.metadata["failed_rule_ids"] == ["u1"]
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_metric_empty_or_malformed_constraints() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_pass_rate",
+        implementation="inverse_ifeval_pass_rate",
+        params={},
+    )
+    metric = InverseIFEvalPassRateMetric(spec)
+    context = MetricContext(
+        sample_id="s4",
+        sample={
+            "metadata": {
+                "constraints": [],
+                "instruction_id_list": [None, "", "not_supported_id"],
+            }
+        },
+        model_output={"answer": "text"},
+        judge_output={},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 0.0
+    assert result.values["passed"] == 0.0
+    assert result.metadata["total_rules"] == 1
+    assert result.metadata["unsupported_rule_ids"] == ["inst_2_not_supported_id"]
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_judge_metric_accepts_numeric_answer() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_judge_pass_rate",
+        implementation="inverse_ifeval_judge_pass_rate",
+        params={"threshold": 0.5},
+    )
+    metric = InverseIFEvalJudgePassRateMetric(spec)
+    context = MetricContext(
+        sample_id="j1",
+        sample={},
+        model_output={},
+        judge_output={"answer": "1"},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 1.0
+    assert result.values["passed"] == 1.0
+    assert result.metadata["judge_source"] == "judge_output.answer"
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_judge_metric_accepts_verdict_tokens() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_judge_pass_rate",
+        implementation="inverse_ifeval_judge_pass_rate",
+        params={"threshold": 0.5},
+    )
+    metric = InverseIFEvalJudgePassRateMetric(spec)
+    context = MetricContext(
+        sample_id="j2",
+        sample={},
+        model_output={},
+        judge_output={"verdict": "FAILED"},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 0.0
+    assert result.values["passed"] == 0.0
+    assert result.metadata["judge_source"] == "judge_output.verdict"
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_judge_metric_accepts_json_answer() -> None:
+    spec = MetricSpec(
+        metric_id="inverse_ifeval_judge_pass_rate",
+        implementation="inverse_ifeval_judge_pass_rate",
+        params={"threshold": 0.5},
+    )
+    metric = InverseIFEvalJudgePassRateMetric(spec)
+    context = MetricContext(
+        sample_id="j3",
+        sample={},
+        model_output={},
+        judge_output={"answer": "{\"score\": 0.83, \"verdict\": \"pass\"}"},
+        args={},
+        trace=None,
+    )
+
+    result = metric.compute(context)
+
+    assert result.values["pass_rate"] == 1.0
+    assert result.metadata["judge_score"] == pytest.approx(0.83)

--- a/tests/unit/assets/test_inverse_ifeval_preprocessor.py
+++ b/tests/unit/assets/test_inverse_ifeval_preprocessor.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from gage_eval.assets.datasets.preprocessors.inverse_ifeval_preprocessor import InverseIFEvalPreprocessor
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_preprocessor_maps_fields() -> None:
+    preprocessor = InverseIFEvalPreprocessor()
+    record = {
+        "id": "sample-1",
+        "prompt": "Return only YES.",
+        "response_reference": "YES",
+        "language": "chinese",
+        "judge_prompt_template": "<Question>: {prompt}\\n<Reference>: {response_reference}\\n<Response>: {response}",
+        "judge_system_prompt": "You are a strict grader.",
+        "constraints": [
+            {"id": "c1", "type": "must_contain", "value": "yes"},
+            {"id": "c2", "type": "max_length", "value": 5},
+        ],
+        "instruction_id_list": ["contains"],
+        "kwargs": {"contains": "yes"},
+        "schema": {"version": "v1"},
+        "answer": "YES",
+    }
+
+    sample = preprocessor.to_sample(record)
+
+    assert sample.id == "sample-1"
+    assert sample.messages[0].role == "user"
+    assert sample.messages[0].content[0].text == "Return only YES."
+    assert sample.references == ["YES"]
+    assert sample.label == "YES"
+    assert sample.metadata is not None
+    assert sample.metadata["constraints"][0]["id"] == "c1"
+    assert sample.metadata["instruction_id_list"] == ["contains"]
+    assert sample.metadata["kwargs"]["contains"] == "yes"
+    assert sample.metadata["raw_schema_fragment"]["version"] == "v1"
+    assert sample.metadata["prompt_text"] == "Return only YES."
+    assert sample.metadata["response_reference"] == "YES"
+    assert sample.metadata["language"] == "chinese"
+    assert sample.metadata["judge_prompt_template"].startswith("<Question>")
+    assert sample.metadata["judge_system_prompt"] == "You are a strict grader."
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_preprocessor_id_fallback_and_prompt_fallback() -> None:
+    preprocessor = InverseIFEvalPreprocessor()
+    record = {
+        "question": "Only output abc.",
+        "constraints": ["abc"],
+    }
+
+    sample = preprocessor.to_sample(record)
+
+    assert sample.id.startswith("inverse_ifeval_")
+    assert sample.messages[0].content[0].text == "Only output abc."
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_preprocessor_empty_references_when_missing() -> None:
+    preprocessor = InverseIFEvalPreprocessor()
+    record = {
+        "sample_id": "s-2",
+        "input": "Reply with one token.",
+        "instruction_ids": ["max_length"],
+        "instruction_kwargs": {"max_length": 1},
+    }
+
+    sample = preprocessor.to_sample(record)
+
+    assert sample.id == "s-2"
+    assert sample.references == []
+    assert sample.label is None
+    assert sample.metadata is not None
+    assert sample.metadata["instruction_id_list"] == ["max_length"]
+    assert sample.metadata["kwargs"]["max_length"] == 1
+
+
+@pytest.mark.fast
+def test_inverse_ifeval_preprocessor_uses_response_reference_as_reference() -> None:
+    preprocessor = InverseIFEvalPreprocessor()
+    record = {
+        "sample_id": "s-3",
+        "input": "Output exactly the keyword.",
+        "response_reference": "keyword",
+    }
+
+    sample = preprocessor.to_sample(record)
+
+    assert sample.references == ["keyword"]
+    assert sample.label == "keyword"
+    assert sample.metadata is not None
+    assert sample.metadata["response_reference"] == "keyword"


### PR DESCRIPTION
The final results are shown below:

{
  "generated_at": "2026-02-25",
  "benchmark": "inverse_ifeval_test",
  "results": [
    {
      "run_id": "inverse_ifeval_qwen25-omni-7b",
      "task_id": "inverse_ifeval_qwen25_omni",
      "sample_count": 1012,
      "inverse_ifeval_judge_pass_rate": 0.6462450592885376,
      "latency_ms": 1395.1257959656093,
      "summary_json_path": "runs/inverse_ifeval_qwen25-omni-7b/summary.json"
    },
    {
      "run_id": "inverse_ifeval_qwen3-omni-30b-a3b",
      "task_id": "inverse_ifeval_qwen3_omni",
      "sample_count": 1012,
      "inverse_ifeval_judge_pass_rate": 0.75,
      "latency_ms": 869.2015237487823,
      "summary_json_path": "runs/inverse_ifeval_qwen3-omni-30b-a3b/summary.json"
    },
    {
      "run_id": "inverse_ifeval_qwen3-vl-30b-a3b",
      "task_id": "inverse_ifeval_qwen3_vl_30b_a3b",
      "sample_count": 1012,
      "inverse_ifeval_judge_pass_rate": 0.7855731225296443,
      "latency_ms": 1549.1063898731127,
      "summary_json_path": "runs/inverse_ifeval_qwen3-vl-30b-a3b/summary.json"
    }
  ]
}
