### PR TITLE
feat(scheduler): The functions of record_scheduler, simultaneous_sche…

### DIFF
--- a/src/gage_eval/role/adapters/arena.py
+++ b/src/gage_eval/role/adapters/arena.py
@@ -19,6 +19,9 @@ from gage_eval.role.arena.interfaces import MoveParser
 from gage_eval.role.arena.players.agent_player import AgentPlayer
 from gage_eval.role.arena.players.human_player import HumanPlayer
 from gage_eval.role.arena.players.llm_player import LLMPlayer
+from gage_eval.role.arena.schedulers.multi_timeline_scheduler import MultiTimelineScheduler
+from gage_eval.role.arena.schedulers.record_scheduler import RecordScheduler
+from gage_eval.role.arena.schedulers.simultaneous_scheduler import SimultaneousScheduler
 from gage_eval.role.arena.schedulers.tick_scheduler import TickScheduler
 from gage_eval.role.arena.schedulers.turn_scheduler import TurnScheduler
 from gage_eval.role.arena.types import GameResult
@@ -204,7 +207,7 @@ class ArenaRoleAdapter(RoleAdapter):
             is_generic_name = False
             if existing_name is not None:
                 normalized_existing = str(existing_name).strip()
-                is_generic_name = bool(re.match(r"^player\\s*\\d+$", normalized_existing, re.IGNORECASE))
+                is_generic_name = bool(re.match(r"^player\s*\d+$", normalized_existing, re.IGNORECASE))
             if existing_name is None or existing_name == normalized["player_id"] or is_generic_name:
                 adapter_ref = normalized.get("ref")
                 if adapter_ref and not normalized.get("name"):
@@ -403,13 +406,126 @@ class ArenaRoleAdapter(RoleAdapter):
     def _build_scheduler(self, sample: Dict[str, Any]):
         cfg = dict(self._scheduler_cfg)
         eval_cfg = sample.get("eval_config") or {}
-        scheduler_type = str(cfg.get("type", "turn"))
+        trace_options = self._resolve_trace_scheduler_options(cfg)
+        scheduler_type = str(cfg.get("type", "turn")).strip().lower()
         max_turns = eval_cfg.get("max_turns", cfg.get("max_turns"))
         if scheduler_type == "tick":
             tick_ms = int(cfg.get("tick_ms", 100))
             max_ticks = cfg.get("max_ticks")
             return TickScheduler(tick_ms=tick_ms, max_ticks=max_ticks)
-        return TurnScheduler(max_turns=max_turns)
+        if scheduler_type == "turn":
+            return TurnScheduler(max_turns=max_turns)
+        if scheduler_type == "record":
+            max_steps = eval_cfg.get("max_turns", cfg.get("max_steps", cfg.get("max_turns")))
+            return RecordScheduler(
+                tick_ms=int(cfg.get("tick_ms", 33)),
+                max_steps=max_steps,
+                action_timeout_ms=cfg.get("action_timeout_ms"),
+                timeout_fallback_move=str(cfg.get("timeout_fallback_move", "NOOP")),
+                timeline_id=cfg.get("timeline_id"),
+                trace_step_index_start=trace_options["step_index_start"],
+                trace_timestamp_clock=trace_options["timestamp_clock"],
+                trace_time_clock=trace_options["time_clock"],
+                trace_finalize_timing=trace_options["finalize_timing"],
+                trace_action_format=trace_options["action_format"],
+            )
+        if scheduler_type == "simultaneous":
+            max_steps = eval_cfg.get("max_turns", cfg.get("max_steps", cfg.get("max_turns")))
+            return SimultaneousScheduler(
+                frames_per_action=int(cfg.get("frames_per_action", 1)),
+                max_steps=max_steps,
+                action_timeout_ms=cfg.get("action_timeout_ms"),
+                timeout_fallback_move=str(cfg.get("timeout_fallback_move", "NOOP")),
+                tick_ms=int(cfg.get("tick_ms", 0)),
+                timeline_id=cfg.get("timeline_id"),
+                trace_step_index_start=trace_options["step_index_start"],
+                trace_timestamp_clock=trace_options["timestamp_clock"],
+                trace_time_clock=trace_options["time_clock"],
+                trace_finalize_timing=trace_options["finalize_timing"],
+                trace_action_format=trace_options["action_format"],
+            )
+        if scheduler_type == "multi_timeline":
+            return MultiTimelineScheduler(
+                tick_ms=int(cfg.get("tick_ms", 33)),
+                max_ticks=cfg.get("max_ticks"),
+                default_fallback_move=str(cfg.get("default_fallback_move", "NOOP")),
+                lane_registry=cfg.get("lane_registry"),
+                timelines=cfg.get("timelines"),
+                trace_step_index_start=trace_options["step_index_start"],
+                trace_timestamp_clock=trace_options["timestamp_clock"],
+                trace_time_clock=trace_options["time_clock"],
+                trace_finalize_timing=trace_options["finalize_timing"],
+                trace_action_format=trace_options["action_format"],
+            )
+        raise ValueError(f"Unsupported scheduler type: {scheduler_type}")
+
+    @staticmethod
+    def _resolve_trace_scheduler_options(cfg: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve trace-related scheduler options from config."""
+
+        trace_cfg = cfg.get("trace")
+        if not isinstance(trace_cfg, dict):
+            trace_cfg = {}
+
+        return {
+            "step_index_start": int(
+                ArenaRoleAdapter._pick_trace_option(
+                    cfg,
+                    trace_cfg,
+                    key="step_index_start",
+                    default=0,
+                )
+            ),
+            "timestamp_clock": str(
+                ArenaRoleAdapter._pick_trace_option(
+                    cfg,
+                    trace_cfg,
+                    key="timestamp_clock",
+                    default="wall_clock",
+                )
+            ),
+            "time_clock": str(
+                ArenaRoleAdapter._pick_trace_option(
+                    cfg,
+                    trace_cfg,
+                    key="time_clock",
+                    default="monotonic",
+                )
+            ),
+            "finalize_timing": str(
+                ArenaRoleAdapter._pick_trace_option(
+                    cfg,
+                    trace_cfg,
+                    key="finalize_timing",
+                    default="after_env_apply",
+                )
+            ),
+            "action_format": str(
+                ArenaRoleAdapter._pick_trace_option(
+                    cfg,
+                    trace_cfg,
+                    key="action_format",
+                    default="flat",
+                )
+            ),
+        }
+
+    @staticmethod
+    def _pick_trace_option(
+        scheduler_cfg: Dict[str, Any],
+        trace_cfg: Dict[str, Any],
+        *,
+        key: str,
+        default: Any,
+    ) -> Any:
+        """Read trace option from nested or flat scheduler config."""
+
+        if key in trace_cfg:
+            return trace_cfg[key]
+        prefixed_key = f"trace_{key}"
+        if prefixed_key in scheduler_cfg:
+            return scheduler_cfg[prefixed_key]
+        return default
 
     def _build_players(
         self,
@@ -502,6 +618,8 @@ class ArenaRoleAdapter(RoleAdapter):
         output.update(self._format_game_log(result.move_log, sample, trace))
         if result.replay_path:
             output["replay_path"] = result.replay_path
+        if result.arena_trace:
+            output["arena_trace"] = list(result.arena_trace)
         return output
 
     def _format_game_log(

--- a/src/gage_eval/role/arena/players/human_player.py
+++ b/src/gage_eval/role/arena/players/human_player.py
@@ -81,7 +81,7 @@ class HumanPlayer:
         return {"role": "user", "content": [{"type": "text", "text": text}]}
 
     def _build_action_metadata(self, parse_result) -> Dict[str, Any]:
-        metadata = {"player_type": "human"}
+        metadata = {"player_type": "human", "retry_count": 0}
         chat_text = getattr(parse_result, "chat_text", None)
         if chat_text:
             metadata["chat"] = str(chat_text)

--- a/src/gage_eval/role/arena/players/llm_player.py
+++ b/src/gage_eval/role/arena/players/llm_player.py
@@ -78,7 +78,7 @@ class LLMPlayer:
                     fallback_move,
                     parse_result.error,
                 )
-                metadata = self._build_action_metadata(parse_result)
+                metadata = self._build_action_metadata(parse_result, retry_count=retries)
                 metadata["error"] = parse_result.error
                 metadata["fallback"] = self._fallback_policy
                 return ArenaAction(
@@ -88,7 +88,7 @@ class LLMPlayer:
                     metadata=metadata,
                 )
 
-        metadata = self._build_action_metadata(parse_result)
+        metadata = self._build_action_metadata(parse_result, retry_count=retries)
         if parse_result.error:
             metadata["error"] = parse_result.error
         return ArenaAction(
@@ -259,11 +259,12 @@ class LLMPlayer:
     def _build_user_message(text: str) -> Dict[str, Any]:
         return {"role": "user", "content": [{"type": "text", "text": text}]}
 
-    def _build_action_metadata(self, parse_result) -> Dict[str, Any]:
+    def _build_action_metadata(self, parse_result, *, retry_count: int = 0) -> Dict[str, Any]:
         metadata = {"player_type": "backend"}
         chat_text = getattr(parse_result, "chat_text", None)
         if chat_text:
             metadata["chat"] = str(chat_text)
+        metadata["retry_count"] = max(0, int(retry_count))
         return metadata
 
 

--- a/src/gage_eval/role/arena/schedulers/__init__.py
+++ b/src/gage_eval/role/arena/schedulers/__init__.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+from gage_eval.role.arena.schedulers.multi_timeline_scheduler import MultiTimelineScheduler
+from gage_eval.role.arena.schedulers.record_scheduler import RecordScheduler
+from gage_eval.role.arena.schedulers.simultaneous_scheduler import SimultaneousScheduler
 from gage_eval.role.arena.schedulers.tick_scheduler import TickScheduler
 from gage_eval.role.arena.schedulers.turn_scheduler import TurnScheduler
 
-__all__ = ["TurnScheduler", "TickScheduler"]
+__all__ = [
+    "TurnScheduler",
+    "TickScheduler",
+    "RecordScheduler",
+    "SimultaneousScheduler",
+    "MultiTimelineScheduler",
+]

--- a/src/gage_eval/role/arena/schedulers/_scheduler_utils.py
+++ b/src/gage_eval/role/arena/schedulers/_scheduler_utils.py
@@ -1,0 +1,359 @@
+"""Shared helper functions for arena scheduler implementations."""
+
+from __future__ import annotations
+
+import threading
+import time
+from queue import Queue
+from typing import Any, Optional
+
+from gage_eval.role.arena.types import ArenaAction, ArenaObservation, GameResult
+
+_ILLEGAL_REASONS = {
+    "invalid_format",
+    "illegal_move",
+    "unknown_player",
+    "wrong_player",
+    "out_of_bounds",
+    "occupied",
+    "illegal_action",
+}
+_VALID_TRACE_CLOCKS = {"wall_clock", "monotonic"}
+_VALID_TRACE_FINALIZE_TIMINGS = {"after_action_submit", "after_env_apply"}
+_VALID_TRACE_ACTION_FORMATS = {"flat", "envelope"}
+
+
+def wall_clock_ms() -> int:
+    """Return current wall-clock timestamp in milliseconds."""
+
+    return int(time.time() * 1000)
+
+
+def monotonic_ms() -> int:
+    """Return monotonic timestamp in milliseconds."""
+
+    return int(time.monotonic() * 1000)
+
+
+def normalize_clock_name(clock: Optional[str], *, default: str) -> str:
+    """Normalize trace clock mode.
+
+    Args:
+        clock: Optional clock mode value.
+        default: Default clock mode when ``clock`` is empty.
+
+    Returns:
+        Normalized clock name.
+
+    Raises:
+        ValueError: If the clock mode is unsupported.
+    """
+
+    value = str(clock or default).strip().lower()
+    if value not in _VALID_TRACE_CLOCKS:
+        supported = ", ".join(sorted(_VALID_TRACE_CLOCKS))
+        raise ValueError(f"Unsupported trace clock '{value}'. Supported: {supported}")
+    return value
+
+
+def normalize_trace_finalize_timing(timing: Optional[str]) -> str:
+    """Normalize trace finalization timing.
+
+    Args:
+        timing: Optional finalization timing string.
+
+    Returns:
+        Normalized timing value.
+
+    Raises:
+        ValueError: If the timing value is unsupported.
+    """
+
+    value = str(timing or "after_env_apply").strip().lower()
+    if value not in _VALID_TRACE_FINALIZE_TIMINGS:
+        supported = ", ".join(sorted(_VALID_TRACE_FINALIZE_TIMINGS))
+        raise ValueError(f"Unsupported trace finalize timing '{value}'. Supported: {supported}")
+    return value
+
+
+def normalize_trace_action_format(action_format: Optional[str]) -> str:
+    """Normalize trace action serialization format.
+
+    Args:
+        action_format: Optional action format value.
+
+    Returns:
+        Normalized action format.
+
+    Raises:
+        ValueError: If the action format value is unsupported.
+    """
+
+    value = str(action_format or "flat").strip().lower()
+    if value not in _VALID_TRACE_ACTION_FORMATS:
+        supported = ", ".join(sorted(_VALID_TRACE_ACTION_FORMATS))
+        raise ValueError(f"Unsupported trace action format '{value}'. Supported: {supported}")
+    return value
+
+
+def clock_ms(clock: str) -> int:
+    """Return current milliseconds from the specified clock.
+
+    Args:
+        clock: Clock mode (`wall_clock` or `monotonic`).
+
+    Returns:
+        Current timestamp in milliseconds.
+    """
+
+    if clock == "wall_clock":
+        return wall_clock_ms()
+    if clock == "monotonic":
+        return monotonic_ms()
+    # NOTE: Callers should normalize first; keep this defensive guard for runtime safety.
+    raise ValueError(f"Unsupported trace clock '{clock}'")
+
+
+def make_trace_entry(
+    *,
+    step_index: int,
+    player_id: str,
+    timestamp_ms: int,
+    t_obs_ready_ms: int,
+    timeline_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Create an in-progress trace entry with F0-required fields.
+
+    Args:
+        step_index: Sequential scheduler step index.
+        player_id: Current action owner.
+        timestamp_ms: Trace event timestamp.
+        t_obs_ready_ms: Observation-ready timestamp.
+        timeline_id: Optional timeline identifier for multi-timeline mode.
+
+    Returns:
+        A trace dictionary initialized with required fields.
+    """
+
+    entry = {
+        "step_index": int(step_index),
+        "trace_state": "in_progress",
+        "timestamp": int(timestamp_ms),
+        "player_id": str(player_id),
+        "action_raw": None,
+        "action_applied": None,
+        "t_obs_ready_ms": int(t_obs_ready_ms),
+        "t_action_submitted_ms": int(t_obs_ready_ms),
+        "timeout": False,
+        "is_action_legal": True,
+        "retry_count": 0,
+    }
+    if timeline_id is not None:
+        entry["timeline_id"] = str(timeline_id)
+    return entry
+
+
+def finalize_trace_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Mark a trace entry as done.
+
+    Args:
+        entry: Trace dictionary created by :func:`make_trace_entry`.
+
+    Returns:
+        The same dictionary with ``trace_state`` finalized.
+    """
+
+    entry["trace_state"] = "done"
+    return entry
+
+
+def set_trace_action_fields(
+    entry: dict[str, Any],
+    action: ArenaAction,
+    *,
+    action_format: str,
+) -> None:
+    """Populate action-related fields according to serialization format.
+
+    Args:
+        entry: Trace entry object.
+        action: Action to serialize into trace.
+        action_format: Serialization format (`flat` or `envelope`).
+    """
+
+    if action_format == "flat":
+        entry["action_raw"] = action.raw
+        entry["action_applied"] = action.move
+        return
+
+    metadata = dict(action.metadata) if isinstance(action.metadata, dict) else {}
+    if action_format == "envelope":
+        entry["action_raw"] = {
+            "player_id": action.player,
+            "raw": action.raw,
+            "metadata": metadata,
+        }
+        entry["action_applied"] = {
+            "player_id": action.player,
+            "move": action.move,
+            "metadata": metadata,
+        }
+        return
+
+    # NOTE: Callers should normalize first; keep this defensive guard for runtime safety.
+    raise ValueError(f"Unsupported trace action format '{action_format}'")
+
+
+def detect_illegal_reason(result: Optional[GameResult]) -> Optional[str]:
+    """Infer illegal-reason tag from a terminal GameResult.
+
+    Args:
+        result: Optional game result returned by environment.apply.
+
+    Returns:
+        Illegal reason string when it matches known reasons, otherwise None.
+    """
+
+    if result is None or not result.reason:
+        return None
+    reason = str(result.reason)
+    if reason in _ILLEGAL_REASONS:
+        return reason
+    return None
+
+
+def infer_retry_count(action: ArenaAction) -> int:
+    """Extract retry count from action metadata when present.
+
+    Args:
+        action: Parsed action object returned by player.
+
+    Returns:
+        Non-negative retry count.
+    """
+
+    value = action.metadata.get("retry_count") if isinstance(action.metadata, dict) else 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def infer_legality(action: ArenaAction) -> bool:
+    """Infer legality from action payload before environment feedback.
+
+    Args:
+        action: Parsed action object returned by player.
+
+    Returns:
+        ``True`` when action appears parse-valid, otherwise ``False``.
+    """
+
+    if not str(action.move or "").strip():
+        return False
+    if isinstance(action.metadata, dict) and action.metadata.get("error"):
+        return False
+    return True
+
+
+def build_fallback_action(
+    *,
+    player_id: str,
+    fallback_move: str,
+    reason: str,
+) -> ArenaAction:
+    """Build a scheduler fallback action.
+
+    Args:
+        player_id: Player identifier.
+        fallback_move: Move text submitted on fallback.
+        reason: Fallback reason tag (for example: ``timeout``).
+
+    Returns:
+        Fallback action with standardized metadata.
+    """
+
+    return ArenaAction(
+        player=str(player_id),
+        move=str(fallback_move),
+        raw=str(fallback_move),
+        metadata={
+            "fallback": str(reason),
+            "error": str(reason),
+            "retry_count": 0,
+        },
+    )
+
+
+def think_with_timeout(
+    *,
+    player: Any,
+    observation: ArenaObservation,
+    timeout_ms: Optional[int],
+) -> tuple[Optional[ArenaAction], bool, Optional[str]]:
+    """Run player.think with optional timeout enforcement.
+
+    Args:
+        player: Player object implementing ``think``.
+        observation: Observation payload to feed the player.
+        timeout_ms: Optional timeout in milliseconds.
+
+    Returns:
+        Tuple ``(action, timed_out, error_type)``.
+    """
+
+    if timeout_ms is None:
+        try:
+            return player.think(observation), False, None
+        except Exception:
+            return None, False, "think_exception"
+
+    timeout_s = max(0.0, float(timeout_ms) / 1000.0)
+    if timeout_s <= 0:
+        return None, True, "timeout"
+
+    result_queue: Queue[tuple[str, Any]] = Queue(maxsize=1)
+
+    def _run_think() -> None:
+        try:
+            action = player.think(observation)
+            result_queue.put_nowait(("ok", action))
+        except Exception as exc:  # pragma: no cover - defensive runtime guard
+            result_queue.put_nowait(("error", exc))
+
+    worker = threading.Thread(target=_run_think, daemon=True)
+    worker.start()
+    worker.join(timeout=timeout_s)
+    if worker.is_alive():
+        return None, True, "timeout"
+
+    if result_queue.empty():
+        return None, False, "empty_result"
+
+    tag, payload = result_queue.get_nowait()
+    if tag == "ok":
+        return payload, False, None
+    return None, False, "think_exception"
+
+
+def apply_action_map(environment: Any, action_map: dict[str, ArenaAction]) -> Optional[GameResult]:
+    """Apply action map once when supported, otherwise sequentially.
+
+    Args:
+        environment: Environment instance from arena adapter.
+        action_map: Mapping from player_id to ArenaAction.
+
+    Returns:
+        Terminal ``GameResult`` when produced, otherwise ``None``.
+    """
+
+    try:
+        return environment.apply(action_map)  # type: ignore[arg-type]
+    except Exception:
+        pass
+
+    for action in action_map.values():
+        outcome = environment.apply(action)
+        if outcome is not None:
+            return outcome
+    return None

--- a/src/gage_eval/role/arena/schedulers/multi_timeline_scheduler.py
+++ b/src/gage_eval/role/arena/schedulers/multi_timeline_scheduler.py
@@ -1,0 +1,328 @@
+"""Multi-timeline scheduler that orchestrates lane-based action collection."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+from gage_eval.role.arena.interfaces import ArenaEnvironment, Player, Scheduler
+from gage_eval.role.arena.schedulers._scheduler_utils import (
+    apply_action_map,
+    build_fallback_action,
+    clock_ms,
+    detect_illegal_reason,
+    finalize_trace_entry,
+    infer_legality,
+    infer_retry_count,
+    make_trace_entry,
+    normalize_clock_name,
+    normalize_trace_action_format,
+    normalize_trace_finalize_timing,
+    set_trace_action_fields,
+    think_with_timeout,
+)
+from gage_eval.role.arena.types import GameResult, attach_arena_trace
+
+
+@dataclass(frozen=True)
+class _LaneConfig:
+    """Runtime lane configuration for multi-timeline orchestration."""
+
+    timeline_id: str
+    player_ids: tuple[str, ...]
+    lane_type: str
+    action_timeout_ms: Optional[int]
+    timeout_fallback_move: str
+
+
+class MultiTimelineScheduler(Scheduler):
+    """Schedule multiple timelines and apply actions in a single global loop."""
+
+    def __init__(
+        self,
+        *,
+        tick_ms: int = 33,
+        max_ticks: Optional[int] = None,
+        default_fallback_move: str = "NOOP",
+        lane_registry: Optional[dict[str, dict[str, Any]]] = None,
+        timelines: Optional[Sequence[dict[str, Any]]] = None,
+        trace_step_index_start: int = 0,
+        trace_timestamp_clock: str = "wall_clock",
+        trace_time_clock: str = "monotonic",
+        trace_finalize_timing: str = "after_env_apply",
+        trace_action_format: str = "flat",
+    ) -> None:
+        """Initialize multi-timeline scheduler.
+
+        Args:
+            tick_ms: Global scheduler tick in milliseconds.
+            max_ticks: Optional maximum global ticks.
+            default_fallback_move: Fallback move when lane config does not provide one.
+            lane_registry: Mapping from lane_ref to lane config.
+            timelines: Ordered timeline configurations.
+            trace_step_index_start: First emitted trace step index.
+            trace_timestamp_clock: Clock mode for ``timestamp`` field.
+            trace_time_clock: Clock mode for ``t_obs_ready_ms``/``t_action_submitted_ms``.
+            trace_finalize_timing: When ``trace_state`` changes to ``done``.
+            trace_action_format: Serialization mode for action fields.
+        """
+
+        self._tick_ms = max(1, int(tick_ms))
+        self._max_ticks = max_ticks if max_ticks is None else max(1, int(max_ticks))
+        self._default_fallback_move = str(default_fallback_move or "NOOP")
+        self._lane_registry = dict(lane_registry or {})
+        self._timelines = list(timelines or [])
+        self._trace_step_index_start = int(trace_step_index_start)
+        self._trace_timestamp_clock = normalize_clock_name(
+            trace_timestamp_clock,
+            default="wall_clock",
+        )
+        self._trace_time_clock = normalize_clock_name(
+            trace_time_clock,
+            default="monotonic",
+        )
+        self._trace_finalize_timing = normalize_trace_finalize_timing(trace_finalize_timing)
+        self._trace_action_format = normalize_trace_action_format(trace_action_format)
+
+    def run_loop(self, environment: ArenaEnvironment, players: Sequence[Player]) -> GameResult:
+        """Run global timeline loop and return final result.
+
+        Args:
+            environment: Arena environment instance.
+            players: Registered players in this match.
+
+        Returns:
+            Final game result with ``arena_trace`` populated.
+        """
+
+        players_by_name = {player.name: player for player in players}
+        if not players_by_name:
+            raise ValueError("MultiTimelineScheduler requires at least one player")
+        player_order = tuple(player.name for player in players)
+
+        lanes = self._build_lanes(players_by_name.keys())
+        if not lanes:
+            raise ValueError("MultiTimelineScheduler requires at least one configured timeline")
+        fallback_moves = self._build_player_fallback_map(lanes)
+
+        # STEP 1: Reset environment and initialize loop state.
+        environment.reset()
+        arena_trace: list[dict] = []
+        tick_index = 0
+        trace_step_index = self._trace_step_index_start
+
+        # STEP 2: Per global tick, collect lane actions then apply once.
+        while not environment.is_terminal():
+            if self._max_ticks is not None and tick_index >= self._max_ticks:
+                result = environment.build_result(result="draw", reason="max_ticks")
+                return attach_arena_trace(result, arena_trace)
+
+            action_map = {}
+            step_entries: list[dict[str, Any]] = []
+            for lane in lanes:
+                lane_player_ids = self._resolve_lane_player_ids(
+                    lane=lane,
+                    environment=environment,
+                )
+                for player_id in lane_player_ids:
+                    player = players_by_name.get(player_id)
+                    if player is None:
+                        raise KeyError(f"Missing player '{player_id}' for timeline '{lane.timeline_id}'")
+
+                    observation = environment.observe(player_id)
+                    t_obs_ready_ms = clock_ms(self._trace_time_clock)
+                    trace_entry = make_trace_entry(
+                        step_index=trace_step_index,
+                        player_id=player_id,
+                        timestamp_ms=clock_ms(self._trace_timestamp_clock),
+                        t_obs_ready_ms=t_obs_ready_ms,
+                        timeline_id=lane.timeline_id,
+                    )
+
+                    action, timed_out, error_type = think_with_timeout(
+                        player=player,
+                        observation=observation,
+                        timeout_ms=lane.action_timeout_ms,
+                    )
+                    if action is None:
+                        fallback_reason = "timeout" if timed_out else (error_type or "think_exception")
+                        action = build_fallback_action(
+                            player_id=player_id,
+                            fallback_move=lane.timeout_fallback_move,
+                            reason=fallback_reason,
+                        )
+
+                    trace_entry["timeout"] = bool(timed_out)
+                    trace_entry["t_action_submitted_ms"] = clock_ms(self._trace_time_clock)
+                    set_trace_action_fields(
+                        trace_entry,
+                        action,
+                        action_format=self._trace_action_format,
+                    )
+                    trace_entry["retry_count"] = infer_retry_count(action)
+                    trace_entry["is_action_legal"] = infer_legality(action)
+                    if isinstance(action.metadata, dict) and action.metadata.get("error"):
+                        trace_entry["illegal_reason"] = str(action.metadata.get("error"))
+
+                    if self._trace_finalize_timing == "after_action_submit":
+                        arena_trace.append(finalize_trace_entry(trace_entry))
+                        step_entries.append(arena_trace[-1])
+                    else:
+                        step_entries.append(trace_entry)
+                    action_map[player_id] = action
+                    trace_step_index += 1
+            action_map = self._complete_action_map(
+                action_map=action_map,
+                player_order=player_order,
+                fallback_moves=fallback_moves,
+            )
+
+            outcome = apply_action_map(environment, action_map)
+            illegal_reason = detect_illegal_reason(outcome)
+            if illegal_reason:
+                for entry in step_entries:
+                    entry["is_action_legal"] = False
+                    entry["illegal_reason"] = illegal_reason
+            if self._trace_finalize_timing == "after_env_apply":
+                for entry in step_entries:
+                    arena_trace.append(finalize_trace_entry(entry))
+            if outcome is not None:
+                return attach_arena_trace(outcome, arena_trace)
+
+            tick_index += 1
+            time.sleep(self._tick_ms / 1000.0)
+
+        # STEP 3: Emit terminal result when environment exits naturally.
+        result = environment.build_result(result="draw", reason="terminated")
+        return attach_arena_trace(result, arena_trace)
+
+    def _resolve_lane_player_ids(
+        self,
+        *,
+        lane: _LaneConfig,
+        environment: ArenaEnvironment,
+    ) -> tuple[str, ...]:
+        """Resolve lane collection targets by lane type.
+
+        Args:
+            lane: Runtime lane configuration.
+            environment: Arena environment instance.
+
+        Returns:
+            Ordered player ids collected in the current global tick.
+        """
+
+        # TODO(zck): Split lane collection into dedicated lane executors - Implement independent
+        # record/simultaneous/tick scheduling semantics instead of a single branch-based selector.
+        if lane.lane_type in {"simultaneous", "tick"}:
+            return lane.player_ids
+
+        # NOTE: Record/turn lanes model a single decision owner per tick.
+        active_player = environment.get_active_player()
+        if active_player in lane.player_ids:
+            return (active_player,)
+        return (lane.player_ids[0],)
+
+    def _build_player_fallback_map(self, lanes: Sequence[_LaneConfig]) -> dict[str, str]:
+        """Build per-player fallback moves from lane configs.
+
+        Args:
+            lanes: Ordered lane configs.
+
+        Returns:
+            Mapping from player_id to fallback move.
+        """
+
+        fallback_by_player: dict[str, str] = {}
+        for lane in lanes:
+            for player_id in lane.player_ids:
+                fallback_by_player.setdefault(player_id, lane.timeout_fallback_move)
+        return fallback_by_player
+
+    def _complete_action_map(
+        self,
+        *,
+        action_map: dict[str, Any],
+        player_order: Sequence[str],
+        fallback_moves: dict[str, str],
+    ) -> dict[str, Any]:
+        """Fill missing player actions to produce a complete action map.
+
+        Args:
+            action_map: Action map collected from lane collectors.
+            player_order: Stable player ordering for deterministic completion.
+            fallback_moves: Per-player fallback move mapping from lane config.
+
+        Returns:
+            Completed action map with every player id populated.
+        """
+
+        completed = dict(action_map)
+        for player_id in player_order:
+            if player_id in completed:
+                continue
+            fallback_move = fallback_moves.get(player_id, self._default_fallback_move)
+            completed[player_id] = build_fallback_action(
+                player_id=player_id,
+                fallback_move=fallback_move,
+                reason="missing_lane_action",
+            )
+        return completed
+
+    def _build_lanes(self, available_player_ids: Sequence[str]) -> list[_LaneConfig]:
+        """Resolve lane references into concrete runtime lane configs.
+
+        Args:
+            available_player_ids: Player ids available in current match.
+
+        Returns:
+            Ordered lane config list.
+        """
+
+        available = {str(player_id) for player_id in available_player_ids}
+        lanes: list[_LaneConfig] = []
+        for index, timeline in enumerate(self._timelines):
+            if not isinstance(timeline, dict):
+                raise ValueError(f"Timeline at index {index} must be a mapping")
+            timeline_id = str(timeline.get("timeline_id") or f"timeline_{index}")
+            player_ids = tuple(str(player_id) for player_id in (timeline.get("player_ids") or []))
+            if not player_ids:
+                raise ValueError(f"Timeline '{timeline_id}' must declare non-empty player_ids")
+            missing_players = [player_id for player_id in player_ids if player_id not in available]
+            if missing_players:
+                missing = ", ".join(missing_players)
+                raise KeyError(f"Timeline '{timeline_id}' references unknown players: {missing}")
+
+            lane_cfg = {}
+            lane_ref = timeline.get("lane_ref")
+            if lane_ref:
+                lane_cfg = self._lane_registry.get(str(lane_ref), {})
+                if not lane_cfg:
+                    raise KeyError(f"Timeline '{timeline_id}' references unknown lane_ref '{lane_ref}'")
+            lane_cfg = dict(lane_cfg)
+
+            lane_type = str(lane_cfg.get("type") or timeline.get("type") or "record").lower()
+            if lane_type not in {"record", "simultaneous", "turn", "tick"}:
+                raise ValueError(f"Unsupported lane type '{lane_type}' for timeline '{timeline_id}'")
+
+            # TODO(zck): Promote lane-specific runtime knobs from config - Wire fields like
+            # frames_per_action/record_fps/keyframe_interval into per-lane execution policies.
+            timeout_value = lane_cfg.get("action_timeout_ms")
+            action_timeout_ms = None if timeout_value is None else max(1, int(timeout_value))
+            fallback_move = str(
+                lane_cfg.get("timeout_fallback_move")
+                or timeline.get("timeout_fallback_move")
+                or self._default_fallback_move
+            )
+
+            lanes.append(
+                _LaneConfig(
+                    timeline_id=timeline_id,
+                    player_ids=player_ids,
+                    lane_type=lane_type,
+                    action_timeout_ms=action_timeout_ms,
+                    timeout_fallback_move=fallback_move,
+                )
+            )
+        return lanes

--- a/src/gage_eval/role/arena/schedulers/record_scheduler.py
+++ b/src/gage_eval/role/arena/schedulers/record_scheduler.py
@@ -1,0 +1,164 @@
+"""Record-style scheduler with per-step trace generation."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional, Sequence
+
+from gage_eval.role.arena.interfaces import ArenaEnvironment, Player, Scheduler
+from gage_eval.role.arena.schedulers._scheduler_utils import (
+    build_fallback_action,
+    clock_ms,
+    detect_illegal_reason,
+    finalize_trace_entry,
+    infer_legality,
+    infer_retry_count,
+    make_trace_entry,
+    normalize_clock_name,
+    normalize_trace_action_format,
+    normalize_trace_finalize_timing,
+    set_trace_action_fields,
+    think_with_timeout,
+)
+from gage_eval.role.arena.types import GameResult, attach_arena_trace
+
+
+class RecordScheduler(Scheduler):
+    """Run turn-like scheduling while producing unified arena trace entries."""
+
+    def __init__(
+        self,
+        *,
+        tick_ms: int = 33,
+        max_steps: Optional[int] = None,
+        action_timeout_ms: Optional[int] = None,
+        timeout_fallback_move: str = "NOOP",
+        timeline_id: Optional[str] = None,
+        trace_step_index_start: int = 0,
+        trace_timestamp_clock: str = "wall_clock",
+        trace_time_clock: str = "monotonic",
+        trace_finalize_timing: str = "after_env_apply",
+        trace_action_format: str = "flat",
+    ) -> None:
+        """Initialize the scheduler.
+
+        Args:
+            tick_ms: Optional pacing interval between steps in milliseconds.
+            max_steps: Optional upper bound on scheduling steps.
+            action_timeout_ms: Optional timeout for per-player think calls.
+            timeout_fallback_move: Move submitted when think call times out.
+            timeline_id: Optional timeline id attached to trace records.
+            trace_step_index_start: First emitted trace step index.
+            trace_timestamp_clock: Clock mode for ``timestamp`` field.
+            trace_time_clock: Clock mode for ``t_obs_ready_ms``/``t_action_submitted_ms``.
+            trace_finalize_timing: When ``trace_state`` changes to ``done``.
+            trace_action_format: Serialization mode for action fields.
+        """
+
+        self._tick_ms = max(0, int(tick_ms))
+        self._max_steps = max_steps if max_steps is None else max(1, int(max_steps))
+        self._action_timeout_ms = (
+            None if action_timeout_ms is None else max(1, int(action_timeout_ms))
+        )
+        self._timeout_fallback_move = str(timeout_fallback_move or "NOOP")
+        self._timeline_id = timeline_id
+        self._trace_step_index_start = int(trace_step_index_start)
+        self._trace_timestamp_clock = normalize_clock_name(
+            trace_timestamp_clock,
+            default="wall_clock",
+        )
+        self._trace_time_clock = normalize_clock_name(
+            trace_time_clock,
+            default="monotonic",
+        )
+        self._trace_finalize_timing = normalize_trace_finalize_timing(trace_finalize_timing)
+        self._trace_action_format = normalize_trace_action_format(trace_action_format)
+
+    def run_loop(self, environment: ArenaEnvironment, players: Sequence[Player]) -> GameResult:
+        """Run the record-style loop and return final result.
+
+        Args:
+            environment: Arena environment instance.
+            players: Registered players in this match.
+
+        Returns:
+            Final game result with ``arena_trace`` populated.
+        """
+
+        players_by_name = {player.name: player for player in players}
+        if not players_by_name:
+            raise ValueError("RecordScheduler requires at least one player")
+
+        # STEP 1: Reset environment and initialize trace state.
+        environment.reset()
+        arena_trace: list[dict] = []
+        step_index = self._trace_step_index_start
+        emitted_steps = 0
+
+        # STEP 2: Run loop and emit one trace entry per decision step.
+        while not environment.is_terminal():
+            if self._max_steps is not None and emitted_steps >= self._max_steps:
+                result = environment.build_result(result="draw", reason="max_steps")
+                return attach_arena_trace(result, arena_trace)
+
+            active_player = environment.get_active_player()
+            player = players_by_name.get(active_player)
+            if player is None:
+                raise KeyError(f"Missing player '{active_player}' for environment")
+
+            observation = environment.observe(active_player)
+            t_obs_ready_ms = clock_ms(self._trace_time_clock)
+            trace_entry = make_trace_entry(
+                step_index=step_index,
+                player_id=active_player,
+                timestamp_ms=clock_ms(self._trace_timestamp_clock),
+                t_obs_ready_ms=t_obs_ready_ms,
+                timeline_id=self._timeline_id,
+            )
+
+            action, timed_out, error_type = think_with_timeout(
+                player=player,
+                observation=observation,
+                timeout_ms=self._action_timeout_ms,
+            )
+            if action is None:
+                fallback_reason = "timeout" if timed_out else (error_type or "think_exception")
+                action = build_fallback_action(
+                    player_id=active_player,
+                    fallback_move=self._timeout_fallback_move,
+                    reason=fallback_reason,
+                )
+            trace_entry["timeout"] = bool(timed_out)
+            trace_entry["t_action_submitted_ms"] = clock_ms(self._trace_time_clock)
+            set_trace_action_fields(
+                trace_entry,
+                action,
+                action_format=self._trace_action_format,
+            )
+            trace_entry["retry_count"] = infer_retry_count(action)
+            trace_entry["is_action_legal"] = infer_legality(action)
+            if isinstance(action.metadata, dict) and action.metadata.get("error"):
+                trace_entry["illegal_reason"] = str(action.metadata.get("error"))
+
+            if self._trace_finalize_timing == "after_action_submit":
+                arena_trace.append(finalize_trace_entry(trace_entry))
+
+            outcome = environment.apply(action)
+            illegal_reason = detect_illegal_reason(outcome)
+            if illegal_reason:
+                trace_entry["is_action_legal"] = False
+                trace_entry["illegal_reason"] = illegal_reason
+            if self._trace_finalize_timing == "after_env_apply":
+                arena_trace.append(finalize_trace_entry(trace_entry))
+
+            if outcome is not None:
+                return attach_arena_trace(outcome, arena_trace)
+
+            step_index += 1
+            emitted_steps += 1
+            if self._tick_ms > 0:
+                time.sleep(self._tick_ms / 1000.0)
+
+        # STEP 3: Emit terminal result when environment exits naturally.
+        result = environment.build_result(result="draw", reason="terminated")
+        return attach_arena_trace(result, arena_trace)

--- a/src/gage_eval/role/arena/schedulers/simultaneous_scheduler.py
+++ b/src/gage_eval/role/arena/schedulers/simultaneous_scheduler.py
@@ -1,0 +1,179 @@
+"""Simultaneous scheduler for multi-player action collection."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional, Sequence
+
+from gage_eval.role.arena.interfaces import ArenaEnvironment, Player, Scheduler
+from gage_eval.role.arena.schedulers._scheduler_utils import (
+    apply_action_map,
+    build_fallback_action,
+    clock_ms,
+    detect_illegal_reason,
+    finalize_trace_entry,
+    infer_legality,
+    infer_retry_count,
+    make_trace_entry,
+    normalize_clock_name,
+    normalize_trace_action_format,
+    normalize_trace_finalize_timing,
+    set_trace_action_fields,
+    think_with_timeout,
+)
+from gage_eval.role.arena.types import GameResult, attach_arena_trace
+
+
+class SimultaneousScheduler(Scheduler):
+    """Collect actions from all players at one decision point."""
+
+    def __init__(
+        self,
+        *,
+        frames_per_action: int = 1,
+        max_steps: Optional[int] = None,
+        action_timeout_ms: Optional[int] = 120,
+        timeout_fallback_move: str = "NOOP",
+        tick_ms: int = 0,
+        timeline_id: Optional[str] = None,
+        trace_step_index_start: int = 0,
+        trace_timestamp_clock: str = "wall_clock",
+        trace_time_clock: str = "monotonic",
+        trace_finalize_timing: str = "after_env_apply",
+        trace_action_format: str = "flat",
+    ) -> None:
+        """Initialize the scheduler.
+
+        Args:
+            frames_per_action: Number of environment advances per decision step.
+            max_steps: Optional upper bound on decision steps.
+            action_timeout_ms: Optional timeout for per-player think calls.
+            timeout_fallback_move: Fallback move when timeout or think error occurs.
+            tick_ms: Optional pacing interval between decision steps.
+            timeline_id: Optional timeline id attached to trace records.
+            trace_step_index_start: First emitted trace step index.
+            trace_timestamp_clock: Clock mode for ``timestamp`` field.
+            trace_time_clock: Clock mode for ``t_obs_ready_ms``/``t_action_submitted_ms``.
+            trace_finalize_timing: When ``trace_state`` changes to ``done``.
+            trace_action_format: Serialization mode for action fields.
+        """
+
+        self._frames_per_action = max(1, int(frames_per_action))
+        self._max_steps = max_steps if max_steps is None else max(1, int(max_steps))
+        self._action_timeout_ms = (
+            None if action_timeout_ms is None else max(1, int(action_timeout_ms))
+        )
+        self._timeout_fallback_move = str(timeout_fallback_move or "NOOP")
+        self._tick_ms = max(0, int(tick_ms))
+        self._timeline_id = timeline_id
+        self._trace_step_index_start = int(trace_step_index_start)
+        self._trace_timestamp_clock = normalize_clock_name(
+            trace_timestamp_clock,
+            default="wall_clock",
+        )
+        self._trace_time_clock = normalize_clock_name(
+            trace_time_clock,
+            default="monotonic",
+        )
+        self._trace_finalize_timing = normalize_trace_finalize_timing(trace_finalize_timing)
+        self._trace_action_format = normalize_trace_action_format(trace_action_format)
+
+    def run_loop(self, environment: ArenaEnvironment, players: Sequence[Player]) -> GameResult:
+        """Run simultaneous action collection loop.
+
+        Args:
+            environment: Arena environment instance.
+            players: Registered players in this match.
+
+        Returns:
+            Final game result with ``arena_trace`` populated.
+        """
+
+        if not players:
+            raise ValueError("SimultaneousScheduler requires at least one player")
+
+        # STEP 1: Reset environment and initialize trace state.
+        environment.reset()
+        arena_trace: list[dict] = []
+        decision_step = 0
+        trace_step_index = self._trace_step_index_start
+
+        # STEP 2: For each decision point, collect one action per player.
+        while not environment.is_terminal():
+            if self._max_steps is not None and decision_step >= self._max_steps:
+                result = environment.build_result(result="draw", reason="max_steps")
+                return attach_arena_trace(result, arena_trace)
+
+            action_map = {}
+            step_entries: list[dict[str, Any]] = []
+            for player in players:
+                observation = environment.observe(player.name)
+                t_obs_ready_ms = clock_ms(self._trace_time_clock)
+                trace_entry = make_trace_entry(
+                    step_index=trace_step_index,
+                    player_id=player.name,
+                    timestamp_ms=clock_ms(self._trace_timestamp_clock),
+                    t_obs_ready_ms=t_obs_ready_ms,
+                    timeline_id=self._timeline_id,
+                )
+
+                action, timed_out, error_type = think_with_timeout(
+                    player=player,
+                    observation=observation,
+                    timeout_ms=self._action_timeout_ms,
+                )
+                if action is None:
+                    fallback_reason = "timeout" if timed_out else (error_type or "think_exception")
+                    action = build_fallback_action(
+                        player_id=player.name,
+                        fallback_move=self._timeout_fallback_move,
+                        reason=fallback_reason,
+                    )
+
+                trace_entry["timeout"] = bool(timed_out)
+                trace_entry["t_action_submitted_ms"] = clock_ms(self._trace_time_clock)
+                set_trace_action_fields(
+                    trace_entry,
+                    action,
+                    action_format=self._trace_action_format,
+                )
+                trace_entry["retry_count"] = infer_retry_count(action)
+                trace_entry["is_action_legal"] = infer_legality(action)
+                if isinstance(action.metadata, dict) and action.metadata.get("error"):
+                    trace_entry["illegal_reason"] = str(action.metadata.get("error"))
+
+                if self._trace_finalize_timing == "after_action_submit":
+                    arena_trace.append(finalize_trace_entry(trace_entry))
+                    step_entries.append(arena_trace[-1])
+                else:
+                    step_entries.append(trace_entry)
+                action_map[player.name] = action
+                trace_step_index += 1
+
+            # STEP 3: Advance environment using collected action map.
+            for _ in range(self._frames_per_action):
+                outcome = apply_action_map(environment, action_map)
+                illegal_reason = detect_illegal_reason(outcome)
+                if illegal_reason:
+                    for entry in step_entries:
+                        entry["is_action_legal"] = False
+                        entry["illegal_reason"] = illegal_reason
+                if outcome is not None:
+                    if self._trace_finalize_timing == "after_env_apply":
+                        for entry in step_entries:
+                            arena_trace.append(finalize_trace_entry(entry))
+                    return attach_arena_trace(outcome, arena_trace)
+                if environment.is_terminal():
+                    break
+
+            if self._trace_finalize_timing == "after_env_apply":
+                for entry in step_entries:
+                    arena_trace.append(finalize_trace_entry(entry))
+
+            decision_step += 1
+            if self._tick_ms > 0:
+                time.sleep(self._tick_ms / 1000.0)
+
+        # STEP 4: Emit terminal result when environment exits naturally.
+        result = environment.build_result(result="draw", reason="terminated")
+        return attach_arena_trace(result, arena_trace)

--- a/src/gage_eval/role/arena/types.py
+++ b/src/gage_eval/role/arena/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Optional, Sequence
 
 
@@ -70,3 +70,21 @@ class GameResult:
     win_direction: Optional[str] = None
     line_length: Optional[int] = None
     replay_path: Optional[str] = None
+    arena_trace: Sequence[dict[str, Any]] = field(default_factory=tuple)
+
+
+def attach_arena_trace(
+    result: GameResult,
+    arena_trace: Sequence[dict[str, Any]],
+) -> GameResult:
+    """Attach scheduler-produced arena trace to a GameResult.
+
+    Args:
+        result: The immutable GameResult instance returned by the environment.
+        arena_trace: Ordered per-step trace entries produced by the scheduler.
+
+    Returns:
+        A new GameResult instance with ``arena_trace`` populated.
+    """
+
+    return replace(result, arena_trace=tuple(arena_trace))

--- a/tests/unit/role/arena/test_arena_adapter_coverage.py
+++ b/tests/unit/role/arena/test_arena_adapter_coverage.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from gage_eval.observability.trace import ObservabilityTrace
+from gage_eval.role.adapters import arena as arena_module
+from gage_eval.role.adapters.arena import ArenaRoleAdapter, _VisualizedEnvironment
+from gage_eval.role.adapters.base import RoleAdapterState
+from gage_eval.role.arena.schedulers.turn_scheduler import TurnScheduler
+from gage_eval.role.arena.types import ArenaObservation, GameResult
+
+
+def _make_result(
+    *,
+    move_log: list[dict[str, Any]] | tuple[dict[str, Any], ...] = (),
+    replay_path: str | None = None,
+    arena_trace: list[dict[str, Any]] | tuple[dict[str, Any], ...] = (),
+) -> GameResult:
+    return GameResult(
+        winner=None,
+        result="draw",
+        reason=None,
+        move_count=len(move_log),
+        illegal_move_count=0,
+        final_board="",
+        move_log=move_log,
+        replay_path=replay_path,
+        arena_trace=arena_trace,
+    )
+
+
+def test_ainvoke_runs_sync_path_in_executor(monkeypatch) -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena")
+    monkeypatch.setattr(adapter, "_invoke_sync", lambda payload, state: {"ok": True, "payload": payload})
+
+    result = asyncio.run(adapter.ainvoke({"sample_id": "s1"}, RoleAdapterState()))
+
+    assert result == {"ok": True, "payload": {"sample_id": "s1"}}
+
+
+def test_build_scheduler_supports_turn_type() -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena", scheduler={"type": " TURN "})
+
+    scheduler = adapter._build_scheduler({"eval_config": {"max_turns": 7}})
+
+    assert isinstance(scheduler, TurnScheduler)
+
+
+def test_normalize_player_specs_prefers_adapter_ref_for_generic_name() -> None:
+    adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        players=[
+            {"id": "p0", "type": "backend", "ref": "backend.alpha"},
+        ],
+    )
+    sample = {
+        "metadata": {
+            "player_ids": ["p0"],
+            "player_names": {"p0": "player 0"},
+        }
+    }
+
+    _, _, player_names, _ = adapter._normalize_player_specs(sample)
+
+    assert player_names["p0"] == "backend.alpha"
+
+
+def test_invoke_sync_mahjong_passes_resolved_player_models(monkeypatch) -> None:
+    adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        environment={"impl": "mahjong_mock_impl"},
+        players=[{"player_id": "p0", "type": "backend", "ref": "backend.alpha"}],
+    )
+    captured_env_kwargs: dict[str, Any] = {}
+
+    class _StubScheduler:
+        def run_loop(self, environment, players) -> GameResult:
+            return _make_result(move_log=[])
+
+    monkeypatch.setattr(
+        adapter,
+        "_normalize_player_specs",
+        lambda sample: (
+            [{"player_id": "p0", "type": "backend", "ref": "backend.alpha"}],
+            ["p0"],
+            {"p0": "P0"},
+            "p0",
+        ),
+    )
+    monkeypatch.setattr(adapter, "_resolve_player_labels", lambda specs, role_manager: {"p0": "model-001"})
+    monkeypatch.setattr(adapter, "_build_parser", lambda sample: object())
+    monkeypatch.setattr(adapter, "_build_scheduler", lambda sample: _StubScheduler())
+    monkeypatch.setattr(adapter, "_ensure_visualizer", lambda sample, player_specs: (None, None))
+    monkeypatch.setattr(adapter, "_ensure_action_server", lambda player_specs: (None, None))
+    monkeypatch.setattr(
+        adapter,
+        "_build_environment",
+        lambda sample, **kwargs: captured_env_kwargs.update(kwargs) or object(),
+    )
+    monkeypatch.setattr(adapter, "_build_players", lambda *args, **kwargs: [object()])
+
+    output = adapter._invoke_sync({"sample": {"metadata": {}}, "role_manager": object()}, RoleAdapterState())
+
+    assert output["result"] == "draw"
+    assert captured_env_kwargs["player_models"] == {"p0": "model-001"}
+
+
+def test_invoke_sync_doudizhu_fills_missing_player_name_from_label(monkeypatch) -> None:
+    adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        environment={"impl": "doudizhu_mock_impl"},
+        players=[{"player_id": "p0", "type": "backend", "ref": "backend.alpha"}],
+    )
+    captured_env_kwargs: dict[str, Any] = {}
+
+    class _StubScheduler:
+        def run_loop(self, environment, players) -> GameResult:
+            return _make_result(move_log=[])
+
+    monkeypatch.setattr(
+        adapter,
+        "_normalize_player_specs",
+        lambda sample: (
+            [{"player_id": "p0", "type": "backend", "ref": "backend.alpha"}],
+            ["p0"],
+            {},
+            "p0",
+        ),
+    )
+    monkeypatch.setattr(adapter, "_resolve_player_labels", lambda specs, role_manager: {"p0": "model-002"})
+    monkeypatch.setattr(adapter, "_build_parser", lambda sample: object())
+    monkeypatch.setattr(adapter, "_build_scheduler", lambda sample: _StubScheduler())
+    monkeypatch.setattr(adapter, "_ensure_visualizer", lambda sample, player_specs: (None, None))
+    monkeypatch.setattr(adapter, "_ensure_action_server", lambda player_specs: (None, None))
+    monkeypatch.setattr(
+        adapter,
+        "_build_environment",
+        lambda sample, **kwargs: captured_env_kwargs.update(kwargs) or object(),
+    )
+    monkeypatch.setattr(adapter, "_build_players", lambda *args, **kwargs: [object()])
+
+    adapter._invoke_sync({"sample": {"metadata": {}}, "role_manager": object()}, RoleAdapterState())
+
+    assert captured_env_kwargs["player_names"]["p0"] == "model-002"
+
+
+def test_build_environment_for_pettingzoo_forwards_optional_kwargs(monkeypatch) -> None:
+    captured_env_kwargs: dict[str, Any] = {}
+
+    class _CapturedEnv:
+        def __init__(self, **kwargs: Any) -> None:
+            captured_env_kwargs.update(kwargs)
+
+    monkeypatch.setattr(arena_module.registry, "get", lambda kind, impl: _CapturedEnv)
+    adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        environment={
+            "impl": "pettingzoo_mock_impl",
+            "env_id": "pong_v3",
+            "env_kwargs": {"frameskip": 4},
+            "seed": 123,
+            "action_labels": {"0": "noop"},
+            "use_action_meanings": True,
+            "include_raw_obs": True,
+            "agent_map": {"first_0": "p0"},
+        },
+    )
+
+    adapter._build_environment(
+        {"metadata": {}},
+        player_ids=["p0"],
+        player_names={"p0": "player0"},
+    )
+
+    assert captured_env_kwargs["env_id"] == "pong_v3"
+    assert captured_env_kwargs["env_kwargs"] == {"frameskip": 4}
+    assert captured_env_kwargs["seed"] == 123
+    assert captured_env_kwargs["action_labels"] == {"0": "noop"}
+    assert captured_env_kwargs["use_action_meanings"] is True
+    assert captured_env_kwargs["include_raw_obs"] is True
+    assert captured_env_kwargs["agent_map"] == {"first_0": "p0"}
+
+
+def test_build_environment_for_mahjong_forwards_run_context_and_models(monkeypatch) -> None:
+    captured_env_kwargs: dict[str, Any] = {}
+    chat_queue = object()
+
+    class _CapturedEnv:
+        def __init__(self, **kwargs: Any) -> None:
+            captured_env_kwargs.update(kwargs)
+
+    monkeypatch.setattr(arena_module.registry, "get", lambda kind, impl: _CapturedEnv)
+    adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        environment={
+            "impl": "mahjong_mock_impl",
+            "chat_every_n": 3,
+            "replay_live": True,
+            "replay_output_dir": "replays",
+            "replay_filename": "sample.json",
+        },
+    )
+    trace = ObservabilityTrace(run_id="run-xyz")
+
+    adapter._build_environment(
+        {"id": "sample-7", "metadata": {}},
+        player_ids=["p0"],
+        player_names={"p0": "player0"},
+        player_models={"p0": "model-007"},
+        chat_queue=chat_queue,
+        trace=trace,
+    )
+
+    assert captured_env_kwargs["run_id"] == "run-xyz"
+    assert captured_env_kwargs["sample_id"] == "sample-7"
+    assert captured_env_kwargs["chat_every_n"] == 3
+    assert captured_env_kwargs["replay_live"] is True
+    assert captured_env_kwargs["replay_output_dir"] == "replays"
+    assert captured_env_kwargs["replay_filename"] == "sample.json"
+    assert captured_env_kwargs["chat_queue"] is chat_queue
+    assert captured_env_kwargs["player_models"] == {"p0": "model-007"}
+
+
+def test_format_result_keeps_small_game_log_and_trace_fields() -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena")
+    result = _make_result(
+        move_log=[{"turn": 1}],
+        replay_path="replay/sample.json",
+        arena_trace=[{"step_index": 1}],
+    )
+
+    output = adapter._format_result(result, {"id": "sample-1"}, None)
+
+    assert output["game_log"] == [{"turn": 1}]
+    assert output["replay_path"] == "replay/sample.json"
+    assert output["arena_trace"] == [{"step_index": 1}]
+
+
+def test_format_game_log_returns_preview_when_no_run_dir(monkeypatch) -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena")
+    monkeypatch.delenv("GAGE_EVAL_RUN_ID", raising=False)
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_INLINE_LIMIT", "0")
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_PREVIEW_LIMIT", "1")
+
+    output = adapter._format_game_log([{"idx": 1}, {"idx": 2}], {"id": "sample-2"}, trace=None)
+
+    assert "game_log_path" not in output
+    assert output["game_log_total"] == 2
+    assert output["game_log_truncated"] is True
+    assert len(output["game_log_preview"]) == 1
+
+
+def test_game_log_helper_limits_and_env_parsing(monkeypatch) -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena")
+    move_log = [{"move": "very-long-move"}]
+
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_INLINE_LIMIT", "0")
+    assert adapter._should_externalize_game_log(move_log) is True
+
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_INLINE_LIMIT", "-1")
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_INLINE_BYTES", "0")
+    assert adapter._should_externalize_game_log(move_log) is False
+
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_INLINE_BYTES", "5")
+    assert adapter._should_externalize_game_log(move_log) is True
+
+    monkeypatch.setattr(adapter, "_estimate_game_log_bytes", lambda _move_log: None)
+    assert adapter._should_externalize_game_log(move_log) is True
+
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_PREVIEW_LIMIT", "1")
+    preview = adapter._preview_game_log([{"idx": 1}, {"idx": 2}])
+    assert preview["game_log_total"] == 2
+    assert preview["game_log_truncated"] is True
+    assert len(preview["game_log_preview"]) == 1
+
+    monkeypatch.setenv("GAGE_EVAL_GAME_LOG_INLINE_BYTES", "invalid")
+    assert adapter._read_int_env("GAGE_EVAL_GAME_LOG_INLINE_BYTES", 42) == 42
+
+
+def test_write_game_log_returns_none_when_directory_creation_fails(tmp_path) -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena")
+    run_dir = tmp_path / "run-1"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "artifacts").write_text("blocked", encoding="utf-8")
+
+    output_path = adapter._write_game_log(run_dir, "sample/1", {"move_log": []})
+
+    assert output_path is None
+
+
+def test_resolve_run_dir_and_sample_id_fallbacks(tmp_path, monkeypatch) -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena")
+    monkeypatch.setenv("GAGE_EVAL_SAVE_DIR", str(tmp_path))
+    monkeypatch.setenv("GAGE_EVAL_RUN_ID", "run-from-env")
+
+    run_dir = adapter._resolve_run_dir(trace=None)
+
+    assert run_dir == (tmp_path / "run-from-env").resolve()
+    assert adapter._resolve_sample_id({"sample_id": 123}) == "123"
+    assert adapter._resolve_sample_id({}) == "sample"
+    assert adapter._sanitize_filename(" sample/id:? ") == "sample_id"
+
+
+def test_estimate_game_log_bytes_returns_none_on_json_error(monkeypatch) -> None:
+    def _raise_type_error(*args: Any, **kwargs: Any) -> str:
+        raise TypeError("bad json")
+
+    monkeypatch.setattr(arena_module.json, "dumps", _raise_type_error)
+
+    assert ArenaRoleAdapter._estimate_game_log_bytes([{"idx": 1}]) is None
+
+
+def test_visualized_environment_uses_last_action_in_status() -> None:
+    class _BaseEnv:
+        def reset(self) -> None:
+            return None
+
+        def get_active_player(self) -> str:
+            return "p0"
+
+        def observe(self, player: str) -> ArenaObservation:
+            return ArenaObservation(
+                board_text="board-state",
+                legal_moves=["A1"],
+                active_player=player,
+                last_move="A1",
+                metadata={"player_names": {"p0": "Alice"}},
+            )
+
+    class _Visualizer:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def update(self, **kwargs: Any) -> None:
+            self.calls.append(kwargs)
+
+    visualizer = _Visualizer()
+    wrapped = _VisualizedEnvironment(_BaseEnv(), visualizer)
+
+    wrapped.reset()
+
+    assert visualizer.calls
+    latest = visualizer.calls[-1]
+    assert latest["status_text"] == "Turn: Alice Last: A1"
+    assert latest["board_text"] == "board-state"
+    assert latest["last_move"] == "A1"

--- a/tests/unit/role/arena/test_new_schedulers.py
+++ b/tests/unit/role/arena/test_new_schedulers.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+import pytest
+
+from gage_eval.role.adapters.arena import ArenaRoleAdapter
+from gage_eval.role.arena.schedulers.multi_timeline_scheduler import MultiTimelineScheduler
+from gage_eval.role.arena.schedulers.record_scheduler import RecordScheduler
+from gage_eval.role.arena.schedulers.simultaneous_scheduler import SimultaneousScheduler
+from gage_eval.role.arena.types import ArenaAction, ArenaObservation, GameResult
+
+
+class _StaticPlayer:
+    def __init__(self, name: str, move: str, *, delay_s: float = 0.0) -> None:
+        self.name = name
+        self._move = move
+        self._delay_s = max(0.0, float(delay_s))
+
+    def think(self, observation: ArenaObservation) -> ArenaAction:
+        if self._delay_s > 0:
+            time.sleep(self._delay_s)
+        return ArenaAction(player=self.name, move=self._move, raw=self._move, metadata={})
+
+
+class _SingleActionEnv:
+    def __init__(self) -> None:
+        self._terminal = False
+        self.applied_actions: list[Any] = []
+
+    def reset(self) -> None:
+        self._terminal = False
+        self.applied_actions = []
+
+    def get_active_player(self) -> str:
+        return "p0"
+
+    def observe(self, player: str) -> ArenaObservation:
+        return ArenaObservation(
+            board_text="",
+            legal_moves=["UP", "NOOP"],
+            active_player=str(player),
+            metadata={},
+        )
+
+    def apply(self, action: Any) -> Optional[GameResult]:
+        self.applied_actions.append(action)
+        self._terminal = True
+        return self.build_result(result="draw", reason="terminated")
+
+    def is_terminal(self) -> bool:
+        return self._terminal
+
+    def build_result(self, *, result: str, reason: Optional[str]) -> GameResult:
+        return GameResult(
+            winner=None,
+            result=result,
+            reason=reason,
+            move_count=len(self.applied_actions),
+            illegal_move_count=0,
+            final_board="",
+            move_log=[],
+        )
+
+
+class _TwoTickDictEnv:
+    def __init__(self, *, max_ticks: int = 2) -> None:
+        self._max_ticks = max(1, int(max_ticks))
+        self._tick_count = 0
+        self.applied_actions: list[Any] = []
+
+    def reset(self) -> None:
+        self._tick_count = 0
+        self.applied_actions = []
+
+    def get_active_player(self) -> str:
+        return "p0"
+
+    def observe(self, player: str) -> ArenaObservation:
+        return ArenaObservation(
+            board_text="",
+            legal_moves=["A", "B", "NOOP"],
+            active_player=str(player),
+            metadata={},
+        )
+
+    def apply(self, action: Any) -> Optional[GameResult]:
+        self.applied_actions.append(action)
+        self._tick_count += 1
+        if self._tick_count >= self._max_ticks:
+            return self.build_result(result="draw", reason="terminated")
+        return None
+
+    def is_terminal(self) -> bool:
+        return self._tick_count >= self._max_ticks
+
+    def build_result(self, *, result: str, reason: Optional[str]) -> GameResult:
+        return GameResult(
+            winner=None,
+            result=result,
+            reason=reason,
+            move_count=self._tick_count,
+            illegal_move_count=0,
+            final_board="",
+            move_log=[],
+        )
+
+
+def test_record_scheduler_timeout_fallback_and_trace() -> None:
+    environment = _SingleActionEnv()
+    player = _StaticPlayer("p0", "UP", delay_s=0.05)
+    scheduler = RecordScheduler(
+        tick_ms=0,
+        action_timeout_ms=5,
+        timeout_fallback_move="NOOP",
+    )
+
+    result = scheduler.run_loop(environment, [player])
+
+    assert environment.applied_actions
+    submitted = environment.applied_actions[0]
+    assert isinstance(submitted, ArenaAction)
+    assert submitted.move == "NOOP"
+    assert result.arena_trace
+    trace = result.arena_trace[0]
+    assert trace["timeout"] is True
+    assert trace["trace_state"] == "done"
+    assert trace["player_id"] == "p0"
+    assert trace["action_applied"] == "NOOP"
+
+
+def test_record_scheduler_trace_options_are_configurable() -> None:
+    environment = _SingleActionEnv()
+    player = _StaticPlayer("p0", "UP")
+    scheduler = RecordScheduler(
+        tick_ms=0,
+        max_steps=1,
+        trace_step_index_start=1,
+        trace_timestamp_clock="monotonic",
+        trace_time_clock="wall_clock",
+        trace_finalize_timing="after_action_submit",
+        trace_action_format="envelope",
+    )
+
+    result = scheduler.run_loop(environment, [player])
+
+    assert len(result.arena_trace) == 1
+    trace = result.arena_trace[0]
+    assert trace["step_index"] == 1
+    assert trace["trace_state"] == "done"
+    assert isinstance(trace["action_raw"], dict)
+    assert isinstance(trace["action_applied"], dict)
+    assert trace["action_raw"]["raw"] == "UP"
+    assert trace["action_applied"]["move"] == "UP"
+    assert trace["t_obs_ready_ms"] - trace["timestamp"] > 1_000_000
+
+
+def test_simultaneous_scheduler_collects_multi_player_actions() -> None:
+    environment = _SingleActionEnv()
+    players = [
+        _StaticPlayer("p0", "UP"),
+        _StaticPlayer("p1", "DOWN", delay_s=0.05),
+    ]
+    scheduler = SimultaneousScheduler(
+        frames_per_action=1,
+        max_steps=1,
+        action_timeout_ms=5,
+        timeout_fallback_move="NOOP",
+        tick_ms=0,
+        trace_step_index_start=3,
+        trace_action_format="envelope",
+    )
+
+    result = scheduler.run_loop(environment, players)
+
+    assert environment.applied_actions
+    action_map = environment.applied_actions[0]
+    assert isinstance(action_map, dict)
+    assert action_map["p0"].move == "UP"
+    assert action_map["p1"].move == "NOOP"
+    assert len(result.arena_trace) == 2
+    assert result.arena_trace[0]["step_index"] == 3
+    assert result.arena_trace[1]["step_index"] == 4
+    assert isinstance(result.arena_trace[0]["action_raw"], dict)
+    assert {entry["player_id"] for entry in result.arena_trace} == {"p0", "p1"}
+
+
+def test_multi_timeline_scheduler_applies_once_per_tick_and_writes_timeline_id() -> None:
+    environment = _TwoTickDictEnv(max_ticks=2)
+    players = [
+        _StaticPlayer("p0", "L"),
+        _StaticPlayer("p1", "R"),
+    ]
+    scheduler = MultiTimelineScheduler(
+        tick_ms=1,
+        max_ticks=2,
+        default_fallback_move="NOOP",
+        trace_step_index_start=10,
+        trace_action_format="envelope",
+        lane_registry={
+            "lane_record_human": {"type": "record", "action_timeout_ms": 50},
+            "lane_sim_ai": {"type": "simultaneous", "action_timeout_ms": 50},
+        },
+        timelines=[
+            {"timeline_id": "timeline_human", "player_ids": ["p0"], "lane_ref": "lane_record_human"},
+            {"timeline_id": "timeline_ai", "player_ids": ["p1"], "lane_ref": "lane_sim_ai"},
+        ],
+    )
+
+    result = scheduler.run_loop(environment, players)
+
+    assert len(environment.applied_actions) == 2
+    assert all(isinstance(action, dict) for action in environment.applied_actions)
+    assert all(set(action.keys()) == {"p0", "p1"} for action in environment.applied_actions)
+    assert len(result.arena_trace) == 4
+    assert [entry["step_index"] for entry in result.arena_trace] == [10, 11, 12, 13]
+    assert isinstance(result.arena_trace[0]["action_applied"], dict)
+    assert {entry.get("timeline_id") for entry in result.arena_trace} == {
+        "timeline_human",
+        "timeline_ai",
+    }
+
+
+def test_multi_timeline_scheduler_classifies_lane_types_and_completes_action_map() -> None:
+    environment = _SingleActionEnv()
+    players = [
+        _StaticPlayer("p0", "L"),
+        _StaticPlayer("p1", "R"),
+        _StaticPlayer("p2", "U"),
+    ]
+    scheduler = MultiTimelineScheduler(
+        tick_ms=1,
+        max_ticks=1,
+        default_fallback_move="NOOP",
+        lane_registry={
+            "lane_record": {"type": "record", "action_timeout_ms": 50, "timeout_fallback_move": "NOOP"},
+            "lane_sim": {"type": "simultaneous", "action_timeout_ms": 50, "timeout_fallback_move": "NOOP"},
+        },
+        timelines=[
+            {"timeline_id": "timeline_record", "player_ids": ["p0", "p1"], "lane_ref": "lane_record"},
+            {"timeline_id": "timeline_sim", "player_ids": ["p2"], "lane_ref": "lane_sim"},
+        ],
+    )
+
+    result = scheduler.run_loop(environment, players)
+
+    assert environment.applied_actions
+    action_map = environment.applied_actions[0]
+    assert isinstance(action_map, dict)
+    assert set(action_map.keys()) == {"p0", "p1", "p2"}
+    assert action_map["p0"].move == "L"
+    assert action_map["p2"].move == "U"
+    assert action_map["p1"].move == "NOOP"
+    assert action_map["p1"].metadata.get("fallback") == "missing_lane_action"
+    assert {entry["player_id"] for entry in result.arena_trace} == {"p0", "p2"}
+
+
+def test_multi_timeline_scheduler_tick_lane_collects_all_lane_players() -> None:
+    environment = _SingleActionEnv()
+    players = [
+        _StaticPlayer("p0", "UP"),
+        _StaticPlayer("p1", "DOWN"),
+    ]
+    scheduler = MultiTimelineScheduler(
+        tick_ms=1,
+        max_ticks=1,
+        default_fallback_move="NOOP",
+        lane_registry={
+            "lane_tick": {"type": "tick", "action_timeout_ms": 50, "timeout_fallback_move": "NOOP"},
+        },
+        timelines=[
+            {"timeline_id": "timeline_tick", "player_ids": ["p0", "p1"], "lane_ref": "lane_tick"},
+        ],
+    )
+
+    result = scheduler.run_loop(environment, players)
+
+    assert environment.applied_actions
+    action_map = environment.applied_actions[0]
+    assert isinstance(action_map, dict)
+    assert set(action_map.keys()) == {"p0", "p1"}
+    assert action_map["p0"].move == "UP"
+    assert action_map["p1"].move == "DOWN"
+    assert action_map["p0"].metadata.get("fallback") is None
+    assert action_map["p1"].metadata.get("fallback") is None
+    assert {entry["player_id"] for entry in result.arena_trace} == {"p0", "p1"}
+
+
+def test_arena_adapter_build_scheduler_supports_new_types() -> None:
+    sample = {"eval_config": {"max_turns": 10}}
+    record_adapter = ArenaRoleAdapter(adapter_id="arena", scheduler={"type": "record"})
+    simultaneous_adapter = ArenaRoleAdapter(adapter_id="arena", scheduler={"type": "simultaneous"})
+    timeline_adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        scheduler={
+            "type": "multi_timeline",
+            "lane_registry": {"lane_record": {"type": "record"}},
+            "timelines": [{"timeline_id": "t0", "player_ids": ["p0"], "lane_ref": "lane_record"}],
+        },
+    )
+
+    assert isinstance(record_adapter._build_scheduler(sample), RecordScheduler)
+    assert isinstance(simultaneous_adapter._build_scheduler(sample), SimultaneousScheduler)
+    assert isinstance(timeline_adapter._build_scheduler(sample), MultiTimelineScheduler)
+
+
+def test_arena_adapter_build_scheduler_applies_trace_options() -> None:
+    sample = {"eval_config": {"max_turns": 10}}
+    adapter = ArenaRoleAdapter(
+        adapter_id="arena",
+        scheduler={
+            "type": "record",
+            "trace_step_index_start": 8,
+            "trace_timestamp_clock": "wall_clock",
+            "trace_time_clock": "wall_clock",
+            "trace_finalize_timing": "after_action_submit",
+            "trace_action_format": "flat",
+            "trace": {
+                "step_index_start": 2,
+                "timestamp_clock": "monotonic",
+                "time_clock": "monotonic",
+            },
+        },
+    )
+
+    scheduler = adapter._build_scheduler(sample)
+
+    assert isinstance(scheduler, RecordScheduler)
+    assert scheduler._trace_step_index_start == 2
+    assert scheduler._trace_timestamp_clock == "monotonic"
+    assert scheduler._trace_time_clock == "monotonic"
+    assert scheduler._trace_finalize_timing == "after_action_submit"
+    assert scheduler._trace_action_format == "flat"
+
+
+def test_arena_adapter_build_scheduler_unknown_type_raises() -> None:
+    adapter = ArenaRoleAdapter(adapter_id="arena", scheduler={"type": "unknown"})
+    with pytest.raises(ValueError, match="Unsupported scheduler type"):
+        adapter._build_scheduler({})


### PR DESCRIPTION
# Summary
This PR delivers the **A-line implementation** for arena trace generation and scheduler orchestration. It introduces a complete multi-mode scheduler stack (`record`, `simultaneous`, `multi_timeline`) and wires it into the Arena adapter, so scheduler-produced trace data can be handed off to B-line normalization without rework.

# Key Changes

## Scheduler Infrastructure (`src/gage_eval/role/arena/schedulers/`)
- Added `RecordScheduler` for per-step trace emission with timeout/fallback handling.
- Added `SimultaneousScheduler` for multi-player action collection at a shared decision point.
- Added `MultiTimelineScheduler` for lane/timeline orchestration with single global apply per tick.
- Added shared utility module `_scheduler_utils.py` for:
  - trace entry build/finalize
  - clock normalization (`wall_clock` / `monotonic`)
  - trace action serialization (`flat` / `envelope`)
  - timeout-safe `think` execution
  - fallback action construction and legality/retry inference
- Updated scheduler exports in `schedulers/__init__.py`.

## Arena Adapter Integration (`src/gage_eval/role/adapters/arena.py`)
- Extended `_build_scheduler` to support:
  - `record`
  - `simultaneous`
  - `multi_timeline`
- Added configurable trace options passthrough:
  - `step_index_start`
  - `timestamp_clock`
  - `time_clock`
  - `finalize_timing`
  - `action_format`
- Improved arena result formatting to include scheduler-produced artifacts (`arena_trace`, `replay_path`) and robust game-log output handling.

## Trace/Type Contract Alignment
- Updated `src/gage_eval/role/arena/types.py` to align arena observation/action/result contracts with the new scheduler trace flow.
- Trace naming keeps `timeout` as the canonical field (no legacy typo variants).

## Player Metadata Alignment
- Updated `src/gage_eval/role/arena/players/human_player.py` and `src/gage_eval/role/arena/players/llm_player.py` to consistently include `retry_count` in action metadata, enabling stable trace retry accounting.

# Testing Status
- Added `tests/unit/role/arena/test_new_schedulers.py` to validate:
  - timeout fallback behavior
  - trace field completeness
  - lane-type behavior (`record/turn` vs `simultaneous/tick`)
  - action-map completion for missing lane actions
- Added `tests/unit/role/arena/test_arena_adapter_coverage.py` to validate adapter integration paths and trace/game-log output behavior.
- Unit test result: `tests/unit/role/arena` passed (`34 passed`).
- A-line changed-line coverage: `85.5%` (`509/595`).
- `arena.py` changed-line coverage: `98.9%` (`174/176`).
