### PR TITLE
fix(runtime): keep single-worker arena samples on calling thread

### DIFF
--- a/src/gage_eval/evaluation/execution_controller.py
+++ b/src/gage_eval/evaluation/execution_controller.py
@@ -94,12 +94,14 @@ class TaskExecutionController:
         failure_policy: FailurePolicy | str | None = None,
         legacy_ff_mode: bool = False,
         report_partial_on_failure: bool = True,
+        inline_sample_execution: bool = False,
     ) -> None:
         self._sample_workers = max(1, int(sample_workers))
         self._metric_workers = max(0, int(metric_workers))
         self._failure_policy = FailurePolicy.parse(failure_policy)
         self._legacy_ff_mode = bool(legacy_ff_mode)
         self._report_partial_on_failure = bool(report_partial_on_failure)
+        self._inline_sample_execution = bool(inline_sample_execution)
         self._sample_executor = ThreadPoolExecutor(
             max_workers=self._sample_workers,
             thread_name_prefix="gage-sample",
@@ -155,6 +157,14 @@ class TaskExecutionController:
         **kwargs: Any,
     ) -> Future[Any]:
         """Submit one sample task to the shared sample lane."""
+
+        if self._inline_sample_execution:
+            return self._run_sample_inline(
+                fn,
+                *args,
+                sample_id=sample_id,
+                **kwargs,
+            )
 
         started = threading.Event()
 
@@ -323,6 +333,26 @@ class TaskExecutionController:
         try:
             future.set_result(fn(*args, **kwargs))
         except BaseException as exc:
+            future.set_exception(exc)
+        return future
+
+    def _run_sample_inline(
+        self,
+        fn: Callable[..., Any],
+        *args: Any,
+        sample_id: str,
+        **kwargs: Any,
+    ) -> Future[Any]:
+        future: Future[Any] = Future()
+        started = threading.Event()
+        with self._lock:
+            self._pending_samples[future] = (sample_id, started)
+        future.add_done_callback(self._sample_done_callback)
+        started.set()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except BaseException as exc:
+            self.record_failure(sample_id, exc)
             future.set_exception(exc)
         return future
 

--- a/src/gage_eval/evaluation/runtime_builder.py
+++ b/src/gage_eval/evaluation/runtime_builder.py
@@ -209,6 +209,9 @@ def _build_single_runtime(
         metric_workers=_resolve_metric_concurrency(None, config.metrics),
         failure_policy=resolved_failure_policy,
         legacy_ff_mode=legacy_ff_mode,
+        inline_sample_execution=(
+            _env_flag("GAGE_EVAL_SEQUENTIAL", default=False) or concurrency <= 1
+        ),
     )
     sample_loop.attach_execution_controller(controller)
     task_planner.attach_execution_controller(controller)
@@ -682,6 +685,9 @@ def _prepare_task_entries(
                 True
                 if plan.runtime_policy.report_partial_on_failure is None
                 else bool(plan.runtime_policy.report_partial_on_failure)
+            ),
+            inline_sample_execution=(
+                _env_flag("GAGE_EVAL_SEQUENTIAL", default=False) or concurrency <= 1
             ),
         )
         sample_loop.attach_execution_controller(controller)

--- a/src/gage_eval/evaluation/sample_loop.py
+++ b/src/gage_eval/evaluation/sample_loop.py
@@ -699,6 +699,7 @@ class SampleLoop:
             failure_policy=self._failure_policy,
             legacy_ff_mode=self._legacy_ff_mode,
             report_partial_on_failure=self._report_partial_on_failure,
+            inline_sample_execution=self._should_run_sequentially(),
         )
         planner.attach_execution_controller(self._execution_controller)
         return self._execution_controller

--- a/tests/unit/config/test_registry_runtime_scope.py
+++ b/tests/unit/config/test_registry_runtime_scope.py
@@ -219,3 +219,64 @@ def test_build_runtime_with_empty_metrics_task_config_is_runtime_guard_safe() ->
     finally:
         runtime.shutdown()
         trace.close(cache_store=None)
+
+
+@pytest.mark.fast
+def test_build_runtime_enables_inline_sample_execution_for_single_worker_tasks() -> None:
+    config = PipelineConfig.from_dict(
+        {
+            "datasets": [
+                {
+                    "dataset_id": "demo_echo_dataset",
+                    "loader": "jsonl",
+                    "params": {
+                        "path": "config/builtin_templates/demo_echo/data/demo_echo.jsonl",
+                        "streaming": False,
+                    },
+                }
+            ],
+            "backends": [
+                {
+                    "backend_id": "demo_echo_dummy",
+                    "type": "dummy",
+                    "config": {"responses": [], "echo_prompt": True, "cycle": True},
+                }
+            ],
+            "role_adapters": [
+                {
+                    "adapter_id": "demo_echo_dut",
+                    "role_type": "dut_model",
+                    "backend_id": "demo_echo_dummy",
+                    "capabilities": ["chat_completion"],
+                }
+            ],
+            "tasks": [
+                {
+                    "task_id": "t1",
+                    "dataset_id": "demo_echo_dataset",
+                    "steps": [{"step": "inference", "adapter_id": "demo_echo_dut"}],
+                    "max_samples": 1,
+                    "concurrency": 1,
+                }
+            ],
+        }
+    )
+    trace = ObservabilityTrace(run_id=f"run-{uuid4().hex}")
+    runtime = build_runtime(
+        config=config,
+        registry=ConfigRegistry(),
+        resource_profile=ResourceProfile(
+            nodes=[NodeResource(node_id="local", gpus=0, cpus=1)]
+        ),
+        trace=trace,
+    )
+
+    try:
+        entry = runtime._tasks[0]
+        controller = entry.sample_loop._execution_controller
+        assert controller is not None
+        assert controller.sample_workers == 1
+        assert getattr(controller, "_inline_sample_execution") is True
+    finally:
+        runtime.shutdown()
+        trace.close(cache_store=None)

--- a/tests/unit/evaluation/test_sample_loop_failure_policy.py
+++ b/tests/unit/evaluation/test_sample_loop_failure_policy.py
@@ -86,6 +86,27 @@ class _FailingInferenceAdapter:
         }
 
 
+class _ThreadCapturingAdapter:
+    role_type = "dut_model"
+    resource_requirement = {}
+    backend = None
+
+    def __init__(self) -> None:
+        self.adapter_id = "dut"
+        self.thread_names: list[str] = []
+
+    def clone_for_sample(self):
+        return self
+
+    def invoke(self, payload, state=None):
+        del payload, state
+        self.thread_names.append(threading.current_thread().name)
+        return {
+            "answer": "ok",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+        }
+
+
 def _build_runtime(
     *,
     failure_policy: str,
@@ -228,3 +249,21 @@ def test_graceful_does_not_count_post_error_failed_samples_as_completed() -> Non
     assert outcome.cancelled_samples >= 1
     assert FakeSandbox.start_calls == 2
     assert len(borrow_calls) == 2
+
+
+@pytest.mark.fast
+def test_sequential_sample_loop_executes_samples_on_calling_thread() -> None:
+    adapter = _ThreadCapturingAdapter()
+    sample_loop, planner, role_manager, trace, _borrow_calls = _build_runtime(
+        failure_policy="fail_fast",
+        sample_count=1,
+        concurrency=1,
+        adapter=adapter,
+    )
+
+    outcome = sample_loop.run(planner, role_manager, trace)
+    sample_loop.shutdown()
+    role_manager.shutdown()
+
+    assert outcome.status == "completed"
+    assert adapter.thread_names == [threading.current_thread().name]


### PR DESCRIPTION
## Summary
This PR keeps single-worker sample execution on the calling thread instead of always routing it through the sample executor. That restores the runtime invariant required by macOS Cocoa / SDL / pygame initialization for PettingZoo human-render environments.

Refs #124.

## Dependency
This PR is intentionally stacked on top of #125 because the runtime/registry regression in #123 blocks the PettingZoo repro before the arena render path can execute.

## Changes
- add an `inline_sample_execution` mode to `TaskExecutionController`
- run sample work inline when runtime assembly resolves a task to effective single-worker execution
- keep `SampleLoop` lazy controller construction aligned with the same single-worker invariant
- add regression coverage for calling-thread execution and runtime-builder wiring for single-worker tasks

## Test Coverage
- Passed: `PYTHONPATH=src /Users/shuo/code/GAGE_workspace/env/.venv/bin/python -m pytest -q tests/unit/evaluation/test_execution_controller.py tests/unit/evaluation/test_sample_loop_failure_policy.py tests/unit/config/test_registry_runtime_scope.py`
- Passed: `PYTHONPATH=src /Users/shuo/code/GAGE_workspace/env/.venv/bin/python run.py --config config/custom/pettingzoo/basketball_pong_dummy.yaml --output-dir /tmp/gage_runs --run-id pettingzoo_basketball_pong_dummy_thread_fix_pr2`

## Review Notes
- The concrete crash being addressed is the macOS AppKit/SDL failure raised from `render_mode=human` when PettingZoo arena startup happens off the main thread.
- Relative to `feat/quality_project`, this branch depends on #125; review this PR against its current base branch for the thread-execution-only delta.
