### PR TITLE
fix(arena): escape mahjong rethink json schema

### DIFF
--- a/src/gage_eval/role/arena/games/mahjong/parsers/mahjong.py
+++ b/src/gage_eval/role/arena/games/mahjong/parsers/mahjong.py
@@ -15,7 +15,7 @@ DEFAULT_RETHINK_TEMPLATE = (
     "Your last output was: '{last_output}'.\n"
     "Instructions:\n"
     "- Output exactly one legal action string from the list below.\n"
-    '- If you include chat, use JSON: {"action": "<action>", "chat": "<short line>"}.\n'
+    '- If you include chat, use JSON: {{"action": "<action>", "chat": "<short line>"}}.\n'
     "Legal moves: {legal_moves}."
 )
 

--- a/tests/unit/role/arena/test_mahjong_parser.py
+++ b/tests/unit/role/arena/test_mahjong_parser.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from gage_eval.role.arena.games.mahjong.parsers.mahjong import StandardMahjongParser
+
+
+def test_mahjong_parser_build_rethink_prompt_keeps_json_schema_literal() -> None:
+    parser = StandardMahjongParser()
+
+    prompt = parser.build_rethink_prompt(
+        last_output="bad output",
+        reason="illegal_move",
+        legal_moves=["B1", "C2"],
+    )
+
+    assert '{"action": "<action>", "chat": "<short line>"}' in prompt
+    assert "Legal moves: B1, C2." in prompt
+
+
+def test_mahjong_parser_parses_json_action_with_chat() -> None:
+    parser = StandardMahjongParser()
+
+    result = parser.parse(
+        '{"action":"B1","chat":"tile talk"}',
+        legal_moves=["B1", "C2"],
+    )
+
+    assert result.action_text == "B1"
+    assert result.chat_text == "tile talk"
+    assert result.error is None


### PR DESCRIPTION
## Summary
This PR fixes the secondary Mahjong retry crash caused by `StandardMahjongParser.build_rethink_prompt()` formatting a literal JSON schema with unescaped braces. When the rethink path is entered, `str.format()` treated `"action"` and `"chat"` as format keys and raised `KeyError('"action"')` instead of returning the retry prompt.

## Changes
- escape the literal JSON example in the Mahjong rethink template so `str.format()` preserves the schema text
- add focused parser regression coverage for rethink prompt rendering and JSON action parsing with chat

## Test Coverage
- Passed: `/Users/shuo/mamba/envs/gage/bin/python -m pytest tests/unit/role/arena/test_mahjong_parser.py -q`

## Review Notes
- This PR fixes the secondary formatter crash only.
- Follow-up bug `#127` tracks the remaining arena behavior where normalized backend failures can still be swallowed into legal fallback moves.
- I did not claim an end-to-end green Mahjong run here because reproducing the original backend path requires model credentials.
