### PR TITLE
fix(datasets): resolve preprocessors and bundles from runtime registry view

### DIFF
--- a/src/gage_eval/assets/datasets/loaders/arcagi2/arcagi2_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/arcagi2/arcagi2_loader.py
@@ -54,6 +54,8 @@ class ARCAGI2DatasetLoader(DatasetLoader):
             raw_records,
             self.spec,
             data_path=str(filesystem_path),
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,

--- a/src/gage_eval/assets/datasets/loaders/base.py
+++ b/src/gage_eval/assets/datasets/loaders/base.py
@@ -7,17 +7,33 @@ from typing import Optional, TYPE_CHECKING
 from gage_eval.config.pipeline_config import DatasetSpec
 from gage_eval.assets.datasets.hubs.base import DatasetHubHandle
 from gage_eval.assets.datasets.manager import DataSource
+from gage_eval.registry import registry
 
 if TYPE_CHECKING:  # pragma: no cover
     from gage_eval.observability.trace import ObservabilityTrace
+    from gage_eval.registry.runtime import RegistryLookup
 
 class DatasetLoader:
     """Base loader that turns hub handles into DataSource objects."""
 
     loader_type = "base"
 
-    def __init__(self, spec: DatasetSpec) -> None:
+    def __init__(
+        self,
+        spec: DatasetSpec,
+        *,
+        registry_view: Optional["RegistryLookup"] = None,
+    ) -> None:
         self.spec = spec
+        self.registry_view = registry_view
+
+    @property
+    def registry_lookup(self):
+        return self.registry_view or registry
+
+    @property
+    def allow_asset_lazy_import(self) -> bool:
+        return self.registry_view is None
 
     def load(
         self,

--- a/src/gage_eval/assets/datasets/loaders/biz_fin_bench/loader.py
+++ b/src/gage_eval/assets/datasets/loaders/biz_fin_bench/loader.py
@@ -64,7 +64,13 @@ def read_jsonl(file_path):
 )
 class HuggingFaceDatasetLoader(DatasetLoader):
     def load(self, hub_handle: Optional[DatasetHubHandle], *, trace=None) -> DataSource:
-        return load_biz_fin_bench_hf_hub_dataset(self.spec, hub_handle, trace=trace)
+        return load_biz_fin_bench_hf_hub_dataset(
+            self.spec,
+            hub_handle,
+            trace=trace,
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
+        )
 
 
 def _normalize_source(raw: str) -> str:
@@ -85,7 +91,14 @@ def _apply_limit(dataset, limit):
     return dataset[:limit]
 
 
-def load_biz_fin_bench_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle] = None, *, trace=None) -> DataSource:
+def load_biz_fin_bench_hf_hub_dataset(
+    spec: DatasetSpec,
+    hub_handle: Optional[DatasetHubHandle] = None,
+    *,
+    trace=None,
+    registry_lookup=None,
+    allow_lazy_import: bool = True,
+) -> DataSource:
     """Download/cache a remote dataset and expose it as a DataSource."""
 
     try:
@@ -151,6 +164,8 @@ def load_biz_fin_bench_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[Da
             benchmark,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             trace=trace,
     )
     #print("records:", records)

--- a/src/gage_eval/assets/datasets/loaders/csv_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/csv_loader.py
@@ -82,6 +82,8 @@ class CSVDatasetLoader(DatasetLoader):
             raw_records,
             self.spec,
             data_path=str(filesystem_path),
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,

--- a/src/gage_eval/assets/datasets/loaders/hf_hub_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/hf_hub_loader.py
@@ -41,7 +41,13 @@ logger = logging.getLogger(__name__)
 )
 class HuggingFaceDatasetLoader(DatasetLoader):
     def load(self, hub_handle: Optional[DatasetHubHandle], *, trace=None) -> DataSource:
-        return load_hf_hub_dataset(self.spec, hub_handle, trace=trace)
+        return load_hf_hub_dataset(
+            self.spec,
+            hub_handle,
+            trace=trace,
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
+        )
 
 
 registry.register(
@@ -63,7 +69,14 @@ registry.register(
 )
 
 
-def load_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle] = None, *, trace=None) -> DataSource:
+def load_hf_hub_dataset(
+    spec: DatasetSpec,
+    hub_handle: Optional[DatasetHubHandle] = None,
+    *,
+    trace=None,
+    registry_lookup=None,
+    allow_lazy_import: bool = True,
+) -> DataSource:
     """Download/cache a remote dataset and expose it as a DataSource."""
 
     try:
@@ -137,6 +150,8 @@ def load_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle
             records,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,
@@ -146,6 +161,8 @@ def load_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle
             records,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,
@@ -179,6 +196,8 @@ def load_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle
             dataset,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,
@@ -189,6 +208,8 @@ def load_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle
             dataset,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,
@@ -505,13 +526,20 @@ def _maybe_apply_bundle(
     spec: DatasetSpec,
     *,
     data_path: str,
+    registry_lookup=None,
+    allow_lazy_import: bool = True,
     doc_to_text=None,
     doc_to_visual=None,
     doc_to_audio=None,
     trace=None,
     observability_config=None,
 ):
-    ctx = build_bundle_context(spec, data_path=data_path)
+    ctx = build_bundle_context(
+        spec,
+        data_path=data_path,
+        registry_lookup=registry_lookup,
+        allow_lazy_import=allow_lazy_import,
+    )
     if not ctx:
         return dataset
     config = observability_config or get_observability_config()
@@ -537,13 +565,20 @@ def _maybe_apply_preprocess(
     spec: DatasetSpec,
     *,
     data_path: str,
+    registry_lookup=None,
+    allow_lazy_import: bool = True,
     doc_to_text=None,
     doc_to_visual=None,
     doc_to_audio=None,
     trace=None,
     observability_config=None,
 ):
-    ctx = build_preprocess_context(spec, data_path=data_path)
+    ctx = build_preprocess_context(
+        spec,
+        data_path=data_path,
+        registry_lookup=registry_lookup,
+        allow_lazy_import=allow_lazy_import,
+    )
     if not ctx:
         return dataset
     config = observability_config or get_observability_config()

--- a/src/gage_eval/assets/datasets/loaders/jsonl_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/jsonl_loader.py
@@ -58,6 +58,8 @@ class JSONLDatasetLoader(DatasetLoader):
             raw_records,
             self.spec,
             data_path=str(filesystem_path),
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,

--- a/src/gage_eval/assets/datasets/loaders/live_code_bench/loader.py
+++ b/src/gage_eval/assets/datasets/loaders/live_code_bench/loader.py
@@ -55,7 +55,13 @@ logger = logging.getLogger(__name__)
 )
 class HuggingFaceDatasetLoader(DatasetLoader):
     def load(self, hub_handle: Optional[DatasetHubHandle], *, trace=None) -> DataSource:
-        return load_live_code_bench_hf_hub_dataset(self.spec, hub_handle, trace=trace)
+        return load_live_code_bench_hf_hub_dataset(
+            self.spec,
+            hub_handle,
+            trace=trace,
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
+        )
 
 
 def _normalize_source(raw: str) -> str:
@@ -76,7 +82,14 @@ def _apply_limit(dataset, limit):
     return dataset[:limit]
 
 
-def load_live_code_bench_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle] = None, *, trace=None) -> DataSource:
+def load_live_code_bench_hf_hub_dataset(
+    spec: DatasetSpec,
+    hub_handle: Optional[DatasetHubHandle] = None,
+    *,
+    trace=None,
+    registry_lookup=None,
+    allow_lazy_import: bool = True,
+) -> DataSource:
     """Download/cache a remote dataset and expose it as a DataSource."""
 
     try:
@@ -158,6 +171,8 @@ def load_live_code_bench_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[
             dataset,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             trace=trace,
     )
 
@@ -184,5 +199,3 @@ def load_live_code_bench_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[
         validation=spec.schema,
         streaming=streaming,
     )
-
-

--- a/src/gage_eval/assets/datasets/loaders/loader_utils.py
+++ b/src/gage_eval/assets/datasets/loaders/loader_utils.py
@@ -22,6 +22,7 @@ from gage_eval.assets.datasets.sample import Sample
 if TYPE_CHECKING:  # pragma: no cover
     from gage_eval.observability.config import ObservabilityConfig
     from gage_eval.observability.trace import ObservabilityTrace
+    from gage_eval.registry.runtime import RegistryLookup
 @dataclass(frozen=True)
 class PreprocessContext:
     """Container describing how to invoke a preprocess handle."""
@@ -83,7 +84,13 @@ def resolve_doc_to_callable(spec: DatasetSpec, field: str) -> Optional[Callable[
     return func
 
 
-def build_preprocess_context(spec: DatasetSpec, *, data_path: Optional[str]) -> Optional[PreprocessContext]:
+def build_preprocess_context(
+    spec: DatasetSpec,
+    *,
+    data_path: Optional[str],
+    registry_lookup: Optional["RegistryLookup"] = None,
+    allow_lazy_import: bool = True,
+) -> Optional[PreprocessContext]:
     """Create a preprocess context shared by JSONL/HF loaders."""
 
     module = spec.params.get("preprocess")
@@ -97,12 +104,25 @@ def build_preprocess_context(spec: DatasetSpec, *, data_path: Optional[str]) -> 
     tokenizer = spec.params.get("tokenizer_object") or load_tokenizer(spec.params)
     if tokenizer is not None:
         kwargs.setdefault("tokenizer", tokenizer)
-    handle = _resolve_registered_preprocessor(module, kwargs)
+    handle = _resolve_registered_preprocessor(
+        module,
+        kwargs,
+        registry_lookup=registry_lookup,
+        allow_lazy_import=allow_lazy_import,
+    )
     if handle:
         return PreprocessContext(handle=handle, kwargs=dict(kwargs))
-    return None
+    raise LookupError(
+        f"Configured dataset preprocessor '{module}' could not be resolved from the active registry lookup"
+    )
 
-def build_bundle_context(spec: DatasetSpec, *, data_path: Optional[str]) -> Optional[BundleContext]:
+def build_bundle_context(
+    spec: DatasetSpec,
+    *,
+    data_path: Optional[str],
+    registry_lookup: Optional["RegistryLookup"] = None,
+    allow_lazy_import: bool = True,
+) -> Optional[BundleContext]:
     """Create a bundle context shared by JSONL/HF loaders."""
 
     module = spec.params.get("bundle")
@@ -111,36 +131,61 @@ def build_bundle_context(spec: DatasetSpec, *, data_path: Optional[str]) -> Opti
     kwargs = coerce_kwargs(spec.params.get("bundle_kwargs"))
     if data_path is not None:
         kwargs.setdefault("data_path", data_path)
-    handle = _resolve_registered_bundle(module, kwargs)
+    handle = _resolve_registered_bundle(
+        module,
+        kwargs,
+        registry_lookup=registry_lookup,
+        allow_lazy_import=allow_lazy_import,
+    )
     if handle:
         return BundleContext(handle=handle, kwargs=dict(kwargs))
-    return None
+    raise LookupError(
+        f"Configured dataset bundle '{module}' could not be resolved from the active registry lookup"
+    )
 
-def _resolve_registered_bundle(name: str, kwargs: Dict[str, Any]):
+def _resolve_registered_bundle(
+    name: str,
+    kwargs: Dict[str, Any],
+    *,
+    registry_lookup: Optional["RegistryLookup"] = None,
+    allow_lazy_import: bool = True,
+):
     """Resolve registered class-based bundle by registry name."""
     if not name:
         return None
+    lookup = registry_lookup or registry
     try:
-        bundle_cls = registry.get("bundles", name)
+        bundle_cls = lookup.get("bundles", name)
     except KeyError:
-        import_dataset_asset_module("bundles", name)
+        if not allow_lazy_import:
+            return None
+        import_dataset_asset_module("bundles", name, registry_lookup=lookup)
         try:
-            bundle_cls = registry.get("bundles", name)
+            bundle_cls = lookup.get("bundles", name)
         except KeyError:
             return None
     bundle = bundle_cls(**kwargs)
     return _BundleAdapter(bundle)
 
-def _resolve_registered_preprocessor(name: str, kwargs: Dict[str, Any]):
+def _resolve_registered_preprocessor(
+    name: str,
+    kwargs: Dict[str, Any],
+    *,
+    registry_lookup: Optional["RegistryLookup"] = None,
+    allow_lazy_import: bool = True,
+):
     """Resolve registered class-based preprocessor by registry name."""
     if not name:
         return None
+    lookup = registry_lookup or registry
     try:
-        preprocessor_cls = registry.get("dataset_preprocessors", name)
+        preprocessor_cls = lookup.get("dataset_preprocessors", name)
     except KeyError:
-        import_dataset_asset_module("dataset_preprocessors", name)
+        if not allow_lazy_import:
+            return None
+        import_dataset_asset_module("dataset_preprocessors", name, registry_lookup=lookup)
         try:
-            preprocessor_cls = registry.get("dataset_preprocessors", name)
+            preprocessor_cls = lookup.get("dataset_preprocessors", name)
         except KeyError:
             return None
     preprocessor = preprocessor_cls(**kwargs)
@@ -164,6 +209,8 @@ def apply_bundle(
     spec: DatasetSpec,
     *,
     data_path: Optional[str],
+    registry_lookup: Optional["RegistryLookup"] = None,
+    allow_lazy_import: bool = True,
     doc_to_text: Optional[Callable[[Dict[str, Any]], Any]] = None,
     doc_to_visual: Optional[Callable[[Dict[str, Any]], Any]] = None,
     doc_to_audio: Optional[Callable[[Dict[str, Any]], Any]] = None,
@@ -171,7 +218,12 @@ def apply_bundle(
     observability_config: Optional["ObservabilityConfig"] = None,
 ) -> Iterable[Dict[str, Any]]:
     config = observability_config or get_observability_config()
-    ctx = build_bundle_context(spec, data_path=data_path)
+    ctx = build_bundle_context(
+        spec,
+        data_path=data_path,
+        registry_lookup=registry_lookup,
+        allow_lazy_import=allow_lazy_import,
+    )
     if not ctx:
         def default_generator():
             for record in records:
@@ -204,6 +256,8 @@ def apply_preprocess(
     spec: DatasetSpec,
     *,
     data_path: Optional[str],
+    registry_lookup: Optional["RegistryLookup"] = None,
+    allow_lazy_import: bool = True,
     doc_to_text: Optional[Callable[[Dict[str, Any]], Any]] = None,
     doc_to_visual: Optional[Callable[[Dict[str, Any]], Any]] = None,
     doc_to_audio: Optional[Callable[[Dict[str, Any]], Any]] = None,
@@ -211,7 +265,12 @@ def apply_preprocess(
     observability_config: Optional["ObservabilityConfig"] = None,
 ) -> Iterable[Dict[str, Any]]:
     config = observability_config or get_observability_config()
-    ctx = build_preprocess_context(spec, data_path=data_path)
+    ctx = build_preprocess_context(
+        spec,
+        data_path=data_path,
+        registry_lookup=registry_lookup,
+        allow_lazy_import=allow_lazy_import,
+    )
     # NOTE: If no explicit preprocess is configured, fall back to DefaultPreprocessor
     # (llm-eval compatible defaults + fallback prompt templating).
     if not ctx:

--- a/src/gage_eval/assets/datasets/loaders/mrcr/mrcr_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/mrcr/mrcr_loader.py
@@ -93,7 +93,13 @@ def _load_data(filename_list):
 )
 class HuggingFaceDatasetLoader(DatasetLoader):
     def load(self, hub_handle: Optional[DatasetHubHandle], *, trace=None) -> DataSource:
-        return openai_mrcr_loader_hf_hub_dataset(self.spec, hub_handle, trace=trace)
+        return openai_mrcr_loader_hf_hub_dataset(
+            self.spec,
+            hub_handle,
+            trace=trace,
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
+        )
 
 def _normalize_source(raw: str) -> str:
     normalized = raw.lower()
@@ -113,7 +119,14 @@ def _apply_limit(dataset, limit):
     return dataset[:limit]
 
 
-def openai_mrcr_loader_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[DatasetHubHandle] = None, *, trace=None) -> DataSource:
+def openai_mrcr_loader_hf_hub_dataset(
+    spec: DatasetSpec,
+    hub_handle: Optional[DatasetHubHandle] = None,
+    *,
+    trace=None,
+    registry_lookup=None,
+    allow_lazy_import: bool = True,
+) -> DataSource:
     """Download/cache a remote dataset and expose it as a DataSource."""
 
     try:
@@ -175,6 +188,8 @@ def openai_mrcr_loader_hf_hub_dataset(spec: DatasetSpec, hub_handle: Optional[Da
             benchmark,
             spec,
             data_path=hub_id,
+            registry_lookup=registry_lookup,
+            allow_lazy_import=allow_lazy_import,
             trace=trace,
     )
     #print("records:", records)

--- a/src/gage_eval/assets/datasets/loaders/parquet_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/parquet_loader.py
@@ -65,6 +65,8 @@ class ParquetDatasetLoader(DatasetLoader):
             raw_records,
             self.spec,
             data_path=str(filesystem_path),
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
             doc_to_text=doc_to_text,
             doc_to_visual=doc_to_visual,
             doc_to_audio=doc_to_audio,

--- a/src/gage_eval/assets/datasets/loaders/tau2_hf_loader.py
+++ b/src/gage_eval/assets/datasets/loaders/tau2_hf_loader.py
@@ -117,6 +117,8 @@ class Tau2TasksLoader(DatasetLoader):
             records,
             self.spec,
             data_path=str(tasks_path),
+            registry_lookup=self.registry_lookup,
+            allow_lazy_import=self.allow_asset_lazy_import,
             trace=trace,
         )
         records = apply_default_params(records, self.spec)

--- a/src/gage_eval/assets/datasets/registry_loader.py
+++ b/src/gage_eval/assets/datasets/registry_loader.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from gage_eval.registry import import_asset_from_manifest, registry
 
 
-def import_dataset_asset_module(kind: str, asset_name: str) -> None:
-    import_asset_from_manifest(str(kind), str(asset_name), registry=registry, source=f"dataset_loader:{kind}")
+def import_dataset_asset_module(kind: str, asset_name: str, *, registry_lookup: Any = None) -> None:
+    target_registry = registry_lookup or registry
+    import_asset_from_manifest(
+        str(kind),
+        str(asset_name),
+        registry=target_registry,
+        source=f"dataset_loader:{kind}",
+    )

--- a/src/gage_eval/config/registry.py
+++ b/src/gage_eval/config/registry.py
@@ -155,7 +155,7 @@ class ConfigRegistry:
                 source=f"dataset:{spec.dataset_id}.loader",
             )
             loader_cls = lookup.get("dataset_loaders", loader_name)
-        loader = loader_cls(spec)
+        loader = loader_cls(spec, registry_view=lookup)
         return loader.load(hub_handle, trace=trace)
 
     def resolve_role_adapter(

--- a/tests/unit/assets/test_jsonl_loader_missing.py
+++ b/tests/unit/assets/test_jsonl_loader_missing.py
@@ -47,3 +47,21 @@ def test_jsonl_loader_default_preprocess_yields_transformed_samples(tmp_path: Pa
     assert sample.inputs["prompt"] == "Hello, gage-eval!"
     assert sample.messages[0].role == "user"
     assert sample.messages[0].content[0].text == "Hello, gage-eval!"
+
+
+@pytest.mark.io
+def test_jsonl_loader_raises_when_configured_preprocess_is_missing(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "demo_echo.jsonl"
+    dataset_path.write_text('{"id":"echo-1","prompt":"Hello, gage-eval!"}\n', encoding="utf-8")
+    spec = DatasetSpec(
+        dataset_id="demo_echo_dataset",
+        loader="jsonl",
+        params={
+            "path": str(dataset_path),
+            "preprocess": "missing_preprocessor_for_test",
+        },
+    )
+    loader = JSONLDatasetLoader(spec)
+
+    with pytest.raises(LookupError, match="Configured dataset preprocessor"):
+        loader.load(None)

--- a/tests/unit/config/test_registry_runtime_scope.py
+++ b/tests/unit/config/test_registry_runtime_scope.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from gage_eval.assets.datasets.loaders.loader_utils import build_bundle_context
 from gage_eval.config.pipeline_config import PipelineConfig, RoleAdapterSpec
 from gage_eval.config.registry import ConfigRegistry, _collect_runtime_registry_packages
 from gage_eval.evaluation.runtime_builder import build_runtime
@@ -111,6 +112,70 @@ def test_prepare_runtime_registry_context_primes_metric_assets_before_runtime_fr
         assert entry.name == metric_name
         metrics = config_registry.with_runtime_registry_context(context).materialize_metrics(config)
         assert metric_name in metrics
+    finally:
+        context.close()
+
+
+@pytest.mark.fast
+def test_runtime_scoped_jsonl_preprocessor_materialization_uses_registry_view(tmp_path) -> None:
+    dataset_path = tmp_path / "appworld.jsonl"
+    dataset_path.write_text(
+        '{"task_id":"task-1","instruction":"Open the settings page."}\n',
+        encoding="utf-8",
+    )
+    config = _build_minimal_config(
+        datasets=[
+            {
+                "dataset_id": "appworld_dataset",
+                "loader": "jsonl",
+                "params": {
+                    "path": str(dataset_path),
+                    "preprocess": "appworld_preprocessor",
+                },
+            }
+        ],
+    )
+    config_registry = ConfigRegistry()
+
+    context = config_registry.prepare_runtime_registry_context(config, run_id=f"run-{uuid4().hex}")
+    try:
+        datasets = config_registry.with_runtime_registry_context(context).materialize_datasets(config)
+        records = list(datasets["appworld_dataset"].records)
+        assert len(records) == 1
+        sample = records[0]
+        assert sample.id == "task-1"
+        assert sample.task_type == "agent"
+        assert sample.messages[0].content[0].text == "Open the settings page."
+    finally:
+        context.close()
+
+
+@pytest.mark.fast
+def test_prepare_runtime_registry_context_primes_dataset_bundle_assets_before_runtime_freeze() -> None:
+    config = _build_minimal_config(
+        datasets=[
+            {
+                "dataset_id": "mme_dataset",
+                "loader": "dummy",
+                "params": {
+                    "bundle": "mme",
+                },
+            }
+        ],
+    )
+    config_registry = ConfigRegistry()
+
+    context = config_registry.prepare_runtime_registry_context(config, run_id=f"run-{uuid4().hex}")
+    try:
+        ctx = build_bundle_context(
+            config.datasets[0],
+            data_path="dummy",
+            registry_lookup=context.view,
+            allow_lazy_import=False,
+        )
+        assert ctx is not None
+        sample = ctx.handle.apply({"image": None}, dataset_id="mme_dataset", dataset_metadata={})
+        assert sample == {"image": None}
     finally:
         context.close()
 


### PR DESCRIPTION
## Summary

Fixes #134 by making dataset loaders resolve configured preprocessors and bundles from the active runtime registry view instead of the global registry after runtime freeze. This restores the invariant that runtime-scoped dataset materialization must not silently degrade into raw dict samples that later surface as empty decoder prompts or chat template failures.

## Changes

- thread the active `registry_view` from `ConfigRegistry` into `DatasetLoader` instances so dataset materialization can use the scoped runtime lookup
- update dataset loader helpers to resolve configured preprocessors and bundles against the provided lookup and only use lazy manifest imports on non-scoped/global paths
- make configured-but-unresolved dataset preprocessors and bundles fail fast during dataset materialization instead of silently passing raw records through
- propagate the scoped lookup through `hf_hub` and other dataset loaders that call shared `apply_*` / `_maybe_apply_*` helpers
- add regression coverage for runtime-scoped jsonl preprocessor materialization, scoped bundle resolution, and missing configured preprocessors

## Test Coverage

- `.venv/bin/python -m pytest tests/unit/config/test_registry_runtime_scope.py -q`
- `.venv/bin/python -m pytest tests/unit/assets/test_jsonl_loader_missing.py -q`

## Review Notes

- Validation was focused on runtime registry contracts and dataset materialization behavior; broader repo-wide suites were not run in this pass.
- I also manually re-verified the original `simpleqa_verified` path with a build-only dataset materialization probe and confirmed that the first sample is again a non-empty `Sample` with two messages under a scoped runtime.
