### PR TITLE
User/pk/static optimize (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 📧 **Contact:** [zhangrongjunchen@myhexin.com](mailto:zhangrongjunchen@myhexin.com)
 
-[Overview](docs/guide/framework_overview.md) · [Sample Schema](docs/guide/sample.md) · [Game Arena](docs/guide/game_arena.md) · [Arena Visual Control](docs/guide/game_arena_topics/game_arena_visual_control.md) · [Agent Eval](docs/guide/agent_evaluation.md) · [Benchmark](docs/guide/benchmark.md) · [Contributing](CONTRIBUTING.md) · [Standards](AGENTS.md)
+[Overview](docs/guide/framework_overview.md) · [Sample Schema](docs/guide/sample.md) · [Smart Defaults](docs/guide/smart_defaults.md) · [Game Arena](docs/guide/game_arena.md) · [Arena Visual Control](docs/guide/game_arena_topics/game_arena_visual_control.md) · [Agent Eval](docs/guide/agent_evaluation.md) · [Benchmark](docs/guide/benchmark.md) · [Contributing](CONTRIBUTING.md) · [Standards](AGENTS.md)
 
 </div>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,7 +8,7 @@
 
 📧 **负责人邮箱:** [zhangrongjunchen@myhexin.com](mailto:zhangrongjunchen@myhexin.com)
 
-[框架总览](docs/guide/framework_overview_zh.md) · [Sample 契约](docs/guide/sample_zh.md) · [Game Arena](docs/guide/game_arena_zh.md) · [Arena Visual 控制面](docs/guide/game_arena_topics/game_arena_visual_control_zh.md) · [Agent 模块](docs/guide/agent_evaluation_zh.md) · [Benchmark](docs/guide/benchmark_zh.md) · [贡献指南](CONTRIBUTING.md) · [编码规范](AGENTS.md)
+[框架总览](docs/guide/framework_overview_zh.md) · [Sample 契约](docs/guide/sample_zh.md) · [智能配置简化](docs/guide/smart_defaults_zh.md) · [Game Arena](docs/guide/game_arena_zh.md) · [Arena Visual 控制面](docs/guide/game_arena_topics/game_arena_visual_control_zh.md) · [Agent 模块](docs/guide/agent_evaluation_zh.md) · [Benchmark](docs/guide/benchmark_zh.md) · [贡献指南](CONTRIBUTING.md) · [编码规范](AGENTS.md)
 
 </div>
 

--- a/config/custom/aime24/aime2024_simple_static.yaml
+++ b/config/custom/aime24/aime2024_simple_static.yaml
@@ -1,0 +1,29 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+metadata:
+  name: aime2024_simple_static
+  description: AIME 2024 simplified static config for local OpenAI-compatible LiteLLM smoke runs.
+
+datasets:
+  - dataset_id: aime2024_ds
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+    params:
+      preprocess: aime2024_preprocessor
+
+backends:
+  - backend_id: local_qwen
+    type: litellm
+    config:
+      provider: openai
+      api_base: http://127.0.0.1:1234/v1
+      model: qwen/qwen3.5-9b
+      api_key: local
+      generation_parameters:
+        max_new_tokens: 512
+        temperature: 0.0
+
+metrics:
+  - metric_id: aime2024_acc
+    implementation: aime2024_accuracy

--- a/config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml
+++ b/config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml
@@ -1,0 +1,149 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+metadata:
+  name: simpleqa_verified_simple_static
+  description: SimpleQA Verified simplified static config using one local LiteLLM backend for both DUT and judge.
+
+custom:
+  steps:
+    - step: inference
+      adapter_id: dut_local_qwen
+    - step: judge
+      adapter_id: judge_local_qwen
+    - step: auto_eval
+
+prompts:
+  - prompt_id: simpleqa_judge_prompt
+    renderer: jinja
+    template: |
+      Your job is to look at a question, a gold target, and a predicted answer, and then assign a grade of either ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"].
+      First, I will give examples of each grade, and then you will grade a new example.
+
+
+      The following are examples of CORRECT predicted answers.
+      ```
+      Question: What are the names of Barack Obama's children?
+      Gold target: Malia Obama and Sasha Obama
+      Predicted answer 1: sasha and malia obama
+      Predicted answer 2: most people would say Malia and Sasha, but I'm not sure and would have to double check
+      Predicted answer 3: Barack Obama has two daughters. Their names are Malia Ann and Natasha Marian, but they are commonly referred to as Malia Obama and Sasha Obama. Malia was born on July 4, 1998, and Sasha was born on June 10, 2001.
+      Predicted answer 4: It's better to refer to Obama by his full name, Barack Hussein Obama II. He has two daughters: Malia and Sasha.
+      ```
+      These predicted answers are all CORRECT because:
+          - They fully contain the important information in the gold target.
+          - They do not contain any information that contradicts the gold target.
+          - Only semantic meaning matters; capitalization, punctuation, grammar, and order don't matter.
+          - Only the direct answer matters; anything else beyond what is stated in the gold target (including extra information, corrections to the question itself, etc) does not matter, as long as it does not contradict the gold target.
+          - Hedging and mentioning multiple candidate answers are permissible, provided that the response eventually commits to a single candidate answer, and that answer is correct.
+
+
+      The following are examples of INCORRECT predicted answers.
+      ```
+      Question: What are the names of Barack Obama's children?
+      Gold target: Malia and Sasha
+      Predicted answer 1: Malia.
+      Predicted answer 2: Malia, Sasha, and Susan.
+      Predicted answer 3: Barack Obama does not have any children.
+      Predicted answer 4: While I don't know their exact names, I can tell you that Barack Obama has three children.
+      Predicted answer 5: It's possible you may mean Betsy and Olivia. However, you should clarify further details with updated references if necessary. Is that the correct answer?
+      Predicted answer 6: It may be the case that Obama's child is named James. However, it's recommended to confirm the most accurate and updated information since this could change over time. This model may not always reflect the most current information.
+      ```
+      These predicted answers are all INCORRECT because:
+          - A factual statement in the answer contradicts the gold target.
+          - A hedged statement (e.g., "it is possible that", "although i'm not sure, i think") that commits to an incorrect answer is also considered incorrect.
+
+
+      The following are examples of NOT_ATTEMPTED predicted answers.
+      ```
+      Question: What are the names of Barack Obama's children?
+      Gold target: Malia and Sasha
+      Predicted answer 1: I don't know.
+      Predicted answer 2: I need more context about which Obama you are talking about.
+      Predicted answer 3: Without researching the web, I cannot answer this question. However, I can tell you that Barack Obama has two children.
+      Predicted answer 4: Barack Obama has two children. I know that one of them is Malia, but I'm not sure about the other one.
+      Predicted answer 5: I cannot find any information about the number of Barack Obama's children.
+      Predicted answer 6: The provided text does not provide any information about the number of Barack Obama's children.
+      Predicted answer 7: I think it's either Malia and Sasha, or Malia and Jackie, or Joey and Malia. I'm not sure which one.
+      ```
+      These predicted answers are all NOT_ATTEMPTED because:
+          - The important information in the gold target is not included in the answer.
+          - No statements in the answer contradict the gold target.
+          - Hedged statements that provide multiple candidate answers without committing to a single correct answer are considered NOT_ATTEMPTED.
+
+
+      Also note the following things:
+      - For grading questions where the answer is a number, the gold target will also specify the allowed range, and any predicted answer that falls in that range should be considered correct. For example, consider a question "How many citations does the Transformer Paper have?" with gold target "120k (acceptable range: anything between 118k and 122k)".
+          - Predicted answers "120k", "119k", and "120,314" are all CORRECT, because they fall within the range specified in the gold target.
+          - Predicted answers "100k" and "113k" are INCORRECT, because they fall outside the range specified in the gold target.
+          - Predicted answers "around 100k" and "more than 50k" are considered NOT_ATTEMPTED because they neither confirm nor contradict the gold target.
+      - The gold target may contain more information than the question. In such cases, the predicted answer only needs to contain the information that is in the question.
+          - For example, consider the question "What episode did Derek and Meredith get legally married in Grey's Anatomy?" with gold target "Season 7, Episode 20: White Wedding". Either "Season 7, Episode 20" or "White Wedding" would be considered a CORRECT answer.
+      - Do not punish predicted answers if they omit information that would be clearly inferred from the question.
+          - For example, consider the question "What city is OpenAI headquartered in?" and the gold target "San Francisco, California". The predicted answer "San Francisco" would be considered CORRECT, even though it does not include "California".
+          - Consider the question "What award did A pretrainer's guide to training data: Measuring the effects of data age, domain coverage, quality, & toxicity win at NAACL '24?", the gold target is "Outstanding Paper Award". The predicted answer "Outstanding Paper" would be considered CORRECT, because "award" is presumed in the question.
+          - For the question "What is the height of Jason Wei in meters?", the gold target is "1.73 m (acceptable range: anything between 1.72 m and 1.74 m)". The predicted answer "1.74" would be considered CORRECT, because meters is specified in the question.
+          - For the question "What is the name of Barack Obama's wife?", the gold target is "Michelle Obama". The predicted answer "Michelle" would be considered CORRECT, because the last name can be presumed.
+      - Do not punish for typos in people's name if it's clearly the same name.
+          - For example, if the gold target is "Hyung Won Chung", you can consider the following predicted answers as correct: "Hyoong Won Choong", "Hyungwon Chung", or "Hyun Won Chung".
+
+
+      Here is a new example. Simply reply with either CORRECT, INCORRECT, NOT ATTEMPTED. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
+      ```
+      Question: {{ (sample.get("messages") or [])[1].content[0].text if (sample.get("messages") and (sample.get("messages")|length) > 1) else ((sample.get("messages") or [])[0].content[0].text if (sample.get("messages") and (sample.get("messages")|length) > 0) else "") }}
+      Gold target: {{ sample.get("label") }}
+      Predicted answer: {{ payload.get("model_output", {}).get("answer") }}
+      ```
+
+      Grade the predicted answer of this new question as one of:
+      A: CORRECT
+      B: INCORRECT
+      C: NOT_ATTEMPTED
+
+      Just return the letters "A", "B", or "C", with no text around it.
+
+datasets:
+  - dataset_id: simpleqa_verified_eval
+    hub_id: google/simpleqa-verified
+    split: eval
+    params:
+      streaming: false
+      preprocess: simpleqa_verified
+      preprocess_kwargs:
+        system_prompt: >
+          You are a factual QA assistant. Answer with a short, direct answer only.
+          Do not add explanations. Do not guess. If you are not sure, say "I don't know".
+        instruction: >
+          Give the final answer only. No extra words, no punctuation beyond what is required.
+
+backends:
+  - backend_id: local_qwen
+    type: litellm
+    config:
+      provider: openai
+      api_base: http://127.0.0.1:1234/v1
+      model: qwen/qwen3.5-9b
+      api_key: local
+      generation_parameters:
+        max_new_tokens: 256
+        temperature: 0.0
+
+role_adapters:
+  - adapter_id: dut_local_qwen
+    role_type: dut_model
+    backend_id: local_qwen
+    capabilities:
+      - chat_completion
+
+  - adapter_id: judge_local_qwen
+    role_type: judge_model
+    backend_id: local_qwen
+    prompt_id: simpleqa_judge_prompt
+    capabilities:
+      - chat_completion
+
+metrics:
+  - metric_id: simpleqa_verified_acc
+    implementation: simpleqa_verified_accuracy
+  - metric_id: simpleqa_verified_judge_acc
+    implementation: simpleqa_verified_judge_accuracy

--- a/docs/guide/smart_defaults.md
+++ b/docs/guide/smart_defaults.md
@@ -1,0 +1,459 @@
+# Smart Defaults Guide
+
+English | [中文](smart_defaults_zh.md)
+
+This guide explains the smart-default configuration workflow across evaluation scenes. The current release implements active rules for `scene: static`; `agent` and `game` are recognized scenes reserved for later phases.
+
+> Path note: commands assume you are in the `gage-eval-main/` repository root.
+
+## 0. Document Map
+
+- Project overview: [`framework_overview.md`](framework_overview.md)
+- Benchmark guide: [`benchmark.md`](benchmark.md)
+- AIME 2024 simplified config: [`config/custom/aime24/aime2024_simple_static.yaml`](../../config/custom/aime24/aime2024_simple_static.yaml)
+- SimpleQA Verified simplified config: [`config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml`](../../config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml)
+
+## 1. What This Feature Is For
+
+In the current release, static benchmark configs are the first target because they often repeat the same boilerplate:
+
+- dataset loader and Hugging Face hub wiring,
+- backend defaults for LiteLLM or vLLM,
+- DUT role adapters,
+- inference and auto-eval steps,
+- single-task declarations,
+- standard console/file reporting.
+
+GAGE still supports complex configurations: multiple backends, multiple datasets, role-specific adapters, sandbox resources, judges, support steps, custom reporting, and other advanced resource combinations. Those capabilities remain available for teams that need them.
+
+**Most day-to-day evaluation runs are simpler. A user often wants to run one benchmark dataset against one model backend, produce one task, and inspect one set of metrics. Smart defaults target this common path. They lower the YAML entry cost for simple evaluations while keeping the explicit configuration model intact for advanced workflows.**
+
+Smart defaults let a config author declare the benchmark-specific parts and let the loader fill predictable framework wiring.
+
+```mermaid
+flowchart LR
+  Short["Simplified YAML"] --> Loader["Config loader"]
+  Loader --> Profile["scene profile"]
+  Profile --> Rules["scene smart-default rules"]
+  Rules --> Normalized["Normalized PipelineConfig"]
+  Normalized --> Runtime["Evaluation runtime"]
+  classDef input fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef process fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  classDef output fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  class Short input;
+  class Loader,Profile,Rules,Normalized process;
+  class Runtime output;
+```
+
+Current planning scope:
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| `scene: static` | Supported | The only scene with active smart-default rules. |
+| Missing `scene` | Legacy behavior | No smart defaults are applied. |
+| `scene: agent` | Recognized no-op | The scene name is accepted, but no simplification rules run. |
+| `scene: game` | Recognized no-op | The scene name is accepted, but no simplification rules run. |
+| Unknown scene | Error | The loader fails fast instead of guessing. |
+
+The feature is intentionally conservative: it fills only missing framework wiring and should not replace explicit user choices.
+
+## 2. Trigger Conditions
+
+Smart defaults are selected from the materialized payload before schema normalization. If the source file is a `RunConfig`, the loader first compiles it into a `PipelineConfig` payload, then applies the same scene selection rules to the compiled payload.
+
+```mermaid
+flowchart TD
+  Start["Load YAML"] --> Env["expand env placeholders"]
+  Env --> RunConfig{"kind is RunConfig?"}
+  RunConfig -- "yes" --> Compile["compile RunConfig"]
+  Compile --> Env
+  RunConfig -- "no" --> Kind{"kind is PipelineConfig?"}
+  Kind -- "no" --> Legacy["legacy profile: no rules"]
+  Kind -- "yes" --> Scene{"scene present?"}
+  Scene -- "no" --> Legacy
+  Scene -- "static" --> Static["static profile: run rules"]
+  Scene -- "agent/game" --> Noop["known scene: no rules"]
+  Scene -- "unknown" --> Error["SmartDefaultsError"]
+  classDef start fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef decision fill:#FFF4D6,stroke:#F2A900,color:#5A3B00;
+  classDef active fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  classDef inactive fill:#F3F4F6,stroke:#9CA3AF,color:#374151;
+  classDef error fill:#FFECEC,stroke:#EB5757,color:#7A1C1C;
+  class Start,Env,Compile start;
+  class RunConfig,Kind,Scene decision;
+  class Static active;
+  class Legacy,Noop inactive;
+  class Error error;
+```
+
+For the currently supported static scene, a simplified config must include:
+
+```yaml
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+```
+
+Useful commands:
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --show-expanded-config
+```
+
+`--show-expanded-config` prints the materialized config and exits. Empty optional top-level sections such as `models`, `agent_backends`, `sandbox_profiles`, `mcp_clients`, `prompts`, and `summary_generators` are hidden only in this display output.
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --show-expanded-config \
+  --no-smart-defaults
+```
+
+`--no-smart-defaults` disables smart-default rule expansion for normal loading or display. When combined with `--show-expanded-config`, it prints the pre-smart-defaults materialized payload after env expansion and optional `RunConfig` compilation, but before smart-default rules, CLI final overrides, `scene` removal, and schema normalization. This mode preserves `scene` and still fails fast for unknown scenes.
+
+## 3. How The Rule Library Works
+
+Smart-default rules are small functions registered by scene, phase, priority, and name. The current static profile runs phases in a fixed order:
+
+```mermaid
+flowchart LR
+  Dataset["dataset"] --> Backend["backend"]
+  Backend --> Role["role_adapter"]
+  Role --> Steps["custom_steps"]
+  Steps --> Task["task"]
+  classDef phase fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  class Dataset,Backend,Role,Steps,Task phase;
+```
+
+The loader applies rules to a deep copy of the payload, then applies CLI final overrides, removes the `scene` marker, and finally normalizes the payload into the regular `PipelineConfig` schema.
+
+```mermaid
+sequenceDiagram
+  participant Config as Config YAML
+  participant Loader as Config loader
+  participant Compiler as RunConfig compiler
+  participant Rules as Scene rules
+  participant CLI as CLI overrides
+  participant Schema as Schema normalization
+
+  Config->>Loader: load YAML and expand env placeholders
+  alt kind=RunConfig
+    Loader->>Compiler: compile RunConfig
+    Compiler-->>Loader: PipelineConfig payload and optional template path
+    Loader->>Loader: materialize compiled payload recursively
+  end
+  Loader->>Rules: select scene profile and apply static rules
+  Rules-->>Loader: return expanded payload
+  Loader->>CLI: apply --max-samples, --metric-ids, --skip-judge
+  Loader->>Schema: remove scene and normalize
+  Schema-->>Loader: PipelineConfig payload
+```
+
+Rule behavior is deliberately explicit. The action column keeps the code-level action identifiers so it can be matched with traces and source code.
+
+| Action | Meaning |
+| --- | --- |
+| `fill` | Add a field only when it is missing. |
+| `migrate` | Move a sugar field into the canonical nested field. |
+| `replace_subtree` | Generate a larger section such as `role_adapters` or `tasks`. |
+| `fail` | Stop loading when a shortcut is ambiguous or contradictory. |
+
+CLI intent can influence expansion:
+
+| CLI option | Effect |
+| --- | --- |
+| `--backend-id` | Static scene only. Skips `task_backend_from_single_dut`, then `task_backend_expand` binds inference to the unique DUT adapter for the selected backend. `agent` and `game` scenes ignore this flag because their profiles currently run no rules. |
+| `--max-samples` | Overrides task `max_samples` and dataset/hub limits after smart defaults. |
+| `--metric-ids` | Filters metrics after smart defaults. |
+| `--skip-judge` | Removes judge steps from `custom.steps` and task steps after smart defaults. |
+
+## 4. Built-In Rules In This Release
+
+The current built-in rule implementation lives in the static scene. Use these files when reading or extending the rule library:
+
+| Area | Code location |
+| --- | --- |
+| Profile selection and scene dispatch | [`src/gage_eval/config/smart_defaults/profiles.py`](../../src/gage_eval/config/smart_defaults/profiles.py) |
+| Rule registration and phase execution | [`src/gage_eval/config/smart_defaults/registry.py`](../../src/gage_eval/config/smart_defaults/registry.py) |
+| Current static rule implementations | [`src/gage_eval/config/smart_defaults/static_rules.py`](../../src/gage_eval/config/smart_defaults/static_rules.py) |
+| CLI intent and final overrides | [`src/gage_eval/config/loader_cli.py`](../../src/gage_eval/config/loader_cli.py) |
+| Config loader integration | [`src/gage_eval/config/loader.py`](../../src/gage_eval/config/loader.py) |
+| `--show-expanded-config` display filtering | [`run.py`](../../run.py) |
+
+The static profile executes phases in this order: `dataset`, `backend`, `role_adapter`, `custom_steps`, `task`. Within a phase, lower priority numbers run first; rules with the same priority are ordered by rule name.
+
+| Phase | Priority | Rule |
+| --- | ---: | --- |
+| `dataset` | 10 | `dataset_hub_from_hub_id` |
+| `dataset` | 10 | `dataset_loader_from_hub_id` |
+| `dataset` | 20 | `dataset_loader_from_path` |
+| `dataset` | 30 | `dataset_hub_params_gather` |
+| `dataset` | 40 | `dataset_preprocess_kwargs_default` |
+| `backend` | 10 | `litellm_api_base_from_provider` |
+| `backend` | 10 | `litellm_provider_from_api_base` |
+| `backend` | 10 | `vllm_tokenizer_path_from_model_path` |
+| `backend` | 20 | `vllm_force_tokenize_prompt_default` |
+| `backend` | 20 | `vllm_tokenizer_trust_remote_code_default` |
+| `backend` | 30 | `litellm_max_retries_default` |
+| `backend` | 30 | `litellm_streaming_default` |
+| `role_adapter` | 20 | `auto_dut_role_adapters` |
+| `custom_steps` | 20 | `auto_custom_steps` |
+| `task` | 5 | `single_task_fallback` |
+| `task` | 6 | `task_singular_alias` |
+| `task` | 10 | `task_implicit_ids` |
+| `task` | 15 | `task_backend_from_single_dut` |
+| `task` | 20 | `task_backend_expand` |
+| `task` | 30 | `task_reporting_default` |
+
+The priority gap in the task phase is intentional: `task_backend_from_single_dut` fills `task.backend` only when that is safe, then `task_backend_expand` consumes either that field or CLI `--backend-id` and writes the concrete inference `adapter_id`.
+
+### 4.1 Dataset Rules
+
+| Rule | What it fills or rewrites | Example input |
+| --- | --- | --- |
+| `dataset_hub_from_hub_id` | Adds `hub: huggingface` when `hub_id` is used. | `hub_id: Maxwell-Jia/AIME_2024` |
+| `dataset_loader_from_hub_id` | Adds `loader: hf_hub` when `hub_id` is used. | `hub_id: google/simpleqa-verified` |
+| `dataset_loader_from_path` | Infers `loader: jsonl` or `loader: json` from a local file path. | `params.path: data/smoke.jsonl` |
+| `dataset_hub_params_gather` | Moves `hub_id`, `split`, `subset`, `revision`, and `data_files` into `hub_params`. | `split: train` |
+| `dataset_preprocess_kwargs_default` | Adds empty `params.preprocess_kwargs` when `params.preprocess` is declared. | `preprocess: aime2024_preprocessor` |
+
+Before:
+
+```yaml
+datasets:
+  - dataset_id: aime2024_ds
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+    params:
+      preprocess: aime2024_preprocessor
+```
+
+After expansion:
+
+```yaml
+datasets:
+  - dataset_id: aime2024_ds
+    hub: huggingface
+    loader: hf_hub
+    hub_params:
+      hub_id: Maxwell-Jia/AIME_2024
+      split: train
+    params:
+      preprocess: aime2024_preprocessor
+      preprocess_kwargs: {}
+```
+
+### 4.2 Backend Rules
+
+| Rule | Applies to | What it fills |
+| --- | --- | --- |
+| `vllm_tokenizer_path_from_model_path` | `type: vllm` | `config.tokenizer_path` from `config.model_path`. |
+| `vllm_force_tokenize_prompt_default` | `type: vllm` | `config.force_tokenize_prompt: true`. |
+| `vllm_tokenizer_trust_remote_code_default` | `type: vllm` | `config.tokenizer_trust_remote_code: true`. |
+| `litellm_provider_from_api_base` | `type: litellm` | `provider` from known API bases such as OpenAI or DeepSeek. |
+| `litellm_api_base_from_provider` | `type: litellm` | Known `api_base` from `provider`. |
+| `litellm_streaming_default` | `type: litellm` | `config.streaming: false`. |
+| `litellm_max_retries_default` | `type: litellm` | `config.max_retries: 6`. |
+
+The two retained example configs use LiteLLM with a local OpenAI-compatible endpoint:
+
+```yaml
+backends:
+  - backend_id: local_qwen
+    type: litellm
+    config:
+      provider: openai
+      api_base: http://127.0.0.1:1234/v1
+      model: qwen/qwen3.5-9b
+      api_key: local
+```
+
+Backend smart defaults stay conservative. They do not infer capacity, token budget, sampling, or model-specific generation settings. Keep these fields explicit when the run depends on them:
+
+| Field family | Examples that are not inferred |
+| --- | --- |
+| vLLM capacity and context | `max_tokens`, `max_model_len`, `gpu_memory_utilization`, `async_max_concurrency` |
+| Sampling controls | `sampling_params`, `temperature`, `top_p` |
+| LiteLLM generation parameters | `generation_parameters.max_new_tokens`, `generation_parameters.temperature` |
+| Backend-specific performance flags | Any backend-specific knob outside the static rule table above |
+
+### 4.3 Role Adapter And Step Rules
+
+| Rule | What it does | When it applies |
+| --- | --- | --- |
+| `auto_dut_role_adapters` | Generates `dut_<backend_id>` adapters with `chat_completion`. | Only when `role_adapters` is omitted. |
+| `auto_custom_steps` | Generates `inference` then `auto_eval`. | Only when every adapter is a DUT adapter and `custom.steps` is missing. |
+
+Pure DUT configs can omit both `role_adapters` and `custom.steps`:
+
+```mermaid
+flowchart LR
+  Backend["backend_id: local_qwen"] --> Adapter["dut_local_qwen"]
+  Adapter --> Inference["inference"]
+  Inference --> Eval["auto_eval"]
+  classDef config fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef inferred fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  classDef run fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  class Backend config;
+  class Adapter inferred;
+  class Inference,Eval run;
+```
+
+Judge configs should still declare their judge adapter and judge step explicitly. The SimpleQA Verified example does this because one local backend is reused as both DUT and judge.
+
+### 4.4 Task Rules
+
+| Rule | What it does |
+| --- | --- |
+| `single_task_fallback` | Creates one task when there is exactly one dataset and one DUT adapter, and no `task` or `tasks` section exists. |
+| `task_singular_alias` | Converts top-level `task:` into a one-item `tasks:` list. |
+| `task_implicit_ids` | Fills `task_id` from `metadata.name` and fills `dataset_id` when there is exactly one dataset. |
+| `task_backend_from_single_dut` | Fills `task.backend` when there is exactly one DUT adapter and no CLI backend override. |
+| `task_backend_expand` | Converts `task.backend` or `--backend-id` into an inference `adapter_id` binding. |
+| `task_reporting_default` | Adds standard console and file reporting sinks. |
+
+Ambiguous shortcuts fail fast. For example, omitting `dataset_id` is only valid when the config declares exactly one dataset.
+
+## 5. Examples
+
+### 5.1 AIME 2024: Pure DUT Static Config
+
+The AIME 2024 simplified config keeps only dataset, backend, and metric declarations. The linked YAML file in the document map is the source of truth; the snippet below mirrors its smart-default-relevant fields and omits only ordinary metadata or generation tuning that does not change the simplification behavior.
+
+```yaml
+scene: static
+metadata:
+  name: aime2024_simple_static
+
+datasets:
+  - dataset_id: aime2024_ds
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+    params:
+      preprocess: aime2024_preprocessor
+
+backends:
+  - backend_id: local_qwen
+    type: litellm
+    config:
+      provider: openai
+      api_base: http://127.0.0.1:1234/v1
+      model: qwen/qwen3.5-9b
+      api_key: local
+
+metrics:
+  - metric_id: aime2024_acc
+    implementation: aime2024_accuracy
+```
+
+The static rules infer:
+
+- Hugging Face dataset loader wiring,
+- LiteLLM retry and streaming defaults,
+- `dut_local_qwen`,
+- `inference -> auto_eval`,
+- one task named `aime2024_simple_static`,
+- standard report sinks.
+
+Run:
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --max-samples 10 \
+  --run-id aime2024_static_smoke
+```
+
+Inspect the expansion:
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --show-expanded-config
+```
+
+### 5.2 SimpleQA Verified: DUT And Judge Static Config
+
+SimpleQA Verified needs a judge step. The simplified config still declares:
+
+- `custom.steps` because the pipeline is `inference -> judge -> auto_eval`,
+- `prompts` because the judge needs a grading prompt,
+- `role_adapters` because `local_qwen` is used as both DUT and judge.
+
+```mermaid
+flowchart LR
+  Dataset["google/simpleqa-verified"] --> Inference["DUT inference"]
+  Inference --> Judge["judge_local_qwen"]
+  Judge --> Eval["auto_eval metrics"]
+  Backend["local_qwen LiteLLM"] --> Inference
+  Backend --> Judge
+  classDef data fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef backend fill:#FFF4D6,stroke:#F2A900,color:#5A3B00;
+  classDef step fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  classDef output fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  class Dataset data;
+  class Backend backend;
+  class Inference,Judge step;
+  class Eval output;
+```
+
+Run:
+
+```bash
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --max-samples 10 \
+  --run-id simpleqa_verified_static_smoke
+```
+
+Useful variants:
+
+```bash
+# Inspect the fully expanded config
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --show-expanded-config
+
+# Keep only one metric
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --metric-ids simpleqa_verified_acc \
+  --max-samples 10 \
+  --run-id simpleqa_verified_acc_only
+
+# Remove judge steps at runtime
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --skip-judge \
+  --max-samples 10 \
+  --run-id simpleqa_verified_no_judge
+```
+
+## 6. Common Errors And Fixes
+
+Smart-default errors are raised as `SmartDefaultsError` and include the field path when the rule can identify one.
+
+| Error text | Common cause | Fix |
+| --- | --- | --- |
+| `Unknown PipelineConfig scene 'research'` | `scene` is not one of the recognized scene names. | Use `scene: static`, `scene: agent`, `scene: game`, or remove `scene` for legacy behavior. |
+| `task and tasks cannot both be declared` | Both the singular shortcut and canonical task list are present. | Keep only `task:` for one task or only `tasks:` for a list. |
+| `task omitted dataset_id but config does not have exactly one dataset at tasks[0]` | A task omits `dataset_id` while multiple datasets are present. | Add `dataset_id` to each task that needs an explicit dataset. |
+| `task omitted backend but config does not have exactly one DUT adapter at tasks[0]` | A task omits `backend` while inference cannot be inferred from one DUT adapter. | Add `task.backend`, pass `--backend-id`, or make `role_adapters` unambiguous. |
+| `cannot find unique DUT adapter for backend 'local_qwen' at cli.backend_id` | `--backend-id` or `task.backend` points to zero or multiple DUT adapters. | Check the backend id and ensure exactly one `role_type: dut_model` adapter uses that backend. |
+| `task must have exactly one inference step to bind backend at tasks[0].steps` | Backend binding needs to patch an inference step, but the task has zero or multiple `step: inference` entries. | Keep one inference step in `custom.steps` or in the task's own `steps`. |
+
+## 7. When To Stay Explicit
+
+Use the simplified form when the config is a normal static benchmark and the inference wiring is predictable.
+
+Stay explicit when the rule library would otherwise have to guess:
+
+- more than one dataset is present and tasks need different datasets,
+- more than one DUT adapter can match the same backend intent; this is a hard failure unless the task or adapters are made unambiguous,
+- the pipeline includes judge, support, custom post-processing, or unusual report sinks,
+- a backend type is not covered by the current scene rules,
+- you are authoring `agent` or `game` scene configs.
+
+The safest workflow is to write the short config, run `--show-expanded-config`, and keep the expanded output under review until the inferred wiring is obvious.

--- a/docs/guide/smart_defaults_zh.md
+++ b/docs/guide/smart_defaults_zh.md
@@ -1,0 +1,459 @@
+# 智能配置简化指南
+
+中文 | [English](smart_defaults.md)
+
+本文说明跨评测场景的智能配置简化功能，包括功能规划、触发条件、智能推断规则库的工作方式、当前内置规则，以及两个保留示例配置的使用方式。本期仅为 `scene: static` 提供实际推断规则；`agent` 和 `game` 是已识别但暂未启用规则的后续场景。
+
+> 路径说明：本文中的命令默认在 `gage-eval-main/` 仓库根目录执行。
+
+## 0. 文档索引
+
+- 项目总览：[`framework_overview_zh.md`](framework_overview_zh.md)
+- Benchmark 指南：[`benchmark_zh.md`](benchmark_zh.md)
+- AIME 2024 简化配置：[`config/custom/aime24/aime2024_simple_static.yaml`](../../config/custom/aime24/aime2024_simple_static.yaml)
+- SimpleQA Verified 简化配置：[`config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml`](../../config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml)
+
+## 1. 配置简化功能规划
+
+本期首先覆盖 static benchmark，因为这类配置中经常存在重复样板：
+
+- 数据集 loader 与 Hugging Face hub 接线，
+- LiteLLM 或 vLLM 后端默认值，
+- DUT role adapter，
+- inference 与 auto_eval 步骤，
+- 单任务声明，
+- console/file reporting。
+
+GAGE 仍然支持复杂配置：多 backend、多 dataset、按角色区分的 adapter、sandbox 资源、judge、support step、自定义 reporting，以及其他高级资源组合。需要复杂编排的团队仍然可以继续显式声明这些配置。
+
+**但大部分日常评测其实更简单：用户通常只是想用一个模型 backend 跑一个 benchmark dataset，生成一个 task，然后查看一组指标。智能配置简化面向这条高频路径，目标是在不削弱高级配置能力的前提下，降低常用评测的 YAML 编写门槛。**
+
+智能配置简化的目标是让配置作者只声明 benchmark 自身差异，把可预测的框架接线交给 loader 自动补齐。
+
+```mermaid
+flowchart LR
+  Short["简化 YAML"] --> Loader["配置加载器"]
+  Loader --> Profile["scene profile"]
+  Profile --> Rules["scene 智能推断规则"]
+  Rules --> Normalized["规范化 PipelineConfig"]
+  Normalized --> Runtime["评测运行时"]
+  classDef input fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef process fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  classDef output fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  class Short input;
+  class Loader,Profile,Rules,Normalized process;
+  class Runtime output;
+```
+
+当前规划范围：
+
+| 范围 | 状态 | 说明 |
+| --- | --- | --- |
+| `scene: static` | 已支持 | 目前唯一启用智能推断规则的场景。 |
+| 缺少 `scene` | 旧行为 | 不启用智能推断，按 legacy 配置处理。 |
+| `scene: agent` | 已识别但 no-op | scene 名称合法，但当前不运行简化规则。 |
+| `scene: game` | 已识别但 no-op | scene 名称合法，但当前不运行简化规则。 |
+| 未知 scene | 报错 | loader fail fast，避免错误配置被静默接受。 |
+
+该功能刻意保持保守：它只补齐缺失的框架接线，不应该覆盖用户已经显式声明的配置。
+
+## 2. 配置简化功能触发条件
+
+智能推断在 schema normalization 之前，根据物化后的 payload 选择 profile。如果源文件是 `RunConfig`，loader 会先把它编译成 `PipelineConfig` payload，再对编译结果应用同一套 scene 选择规则。
+
+```mermaid
+flowchart TD
+  Start["读取 YAML"] --> Env["展开环境变量占位符"]
+  Env --> RunConfig{"kind 是 RunConfig?"}
+  RunConfig -- "是" --> Compile["编译 RunConfig"]
+  Compile --> Env
+  RunConfig -- "否" --> Kind{"kind 是 PipelineConfig?"}
+  Kind -- "否" --> Legacy["legacy profile: 不运行规则"]
+  Kind -- "是" --> Scene{"是否声明 scene?"}
+  Scene -- "否" --> Legacy
+  Scene -- "static" --> Static["static profile: 运行规则"]
+  Scene -- "agent/game" --> Noop["已知 scene: no-op"]
+  Scene -- "未知" --> Error["SmartDefaultsError"]
+  classDef start fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef decision fill:#FFF4D6,stroke:#F2A900,color:#5A3B00;
+  classDef active fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  classDef inactive fill:#F3F4F6,stroke:#9CA3AF,color:#374151;
+  classDef error fill:#FFECEC,stroke:#EB5757,color:#7A1C1C;
+  class Start,Env,Compile start;
+  class RunConfig,Kind,Scene decision;
+  class Static active;
+  class Legacy,Noop inactive;
+  class Error error;
+```
+
+对于当前已支持的 static scene，简化配置必须包含：
+
+```yaml
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+```
+
+常用检查命令：
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --show-expanded-config
+```
+
+`--show-expanded-config` 会打印智能推断后的配置并退出。仅在展示输出中，空的可选顶层字段会被隐藏，例如 `models`、`agent_backends`、`sandbox_profiles`、`mcp_clients`、`prompts`、`summary_generators`。
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --show-expanded-config \
+  --no-smart-defaults
+```
+
+`--no-smart-defaults` 会禁用智能推断规则展开，适合排查“原始配置”和“推断后配置”的差异。它与 `--show-expanded-config` 组合时，会打印 pre-smart-defaults 的物化 payload：此时已经完成环境变量展开和可选的 `RunConfig` 编译，但尚未执行智能推断、CLI final overrides、`scene` 移除和 schema normalization。这个模式会保留 `scene`，并且仍会对未知 scene fail fast。
+
+## 3. 智能推断规则库功能介绍
+
+智能推断规则是按 scene、phase、priority、name 注册的小型函数。当前 static profile 固定按以下阶段执行：
+
+```mermaid
+flowchart LR
+  Dataset["dataset"] --> Backend["backend"]
+  Backend --> Role["role_adapter"]
+  Role --> Steps["custom_steps"]
+  Steps --> Task["task"]
+  classDef phase fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  class Dataset,Backend,Role,Steps,Task phase;
+```
+
+loader 会先对 payload 执行环境变量展开，再对副本应用 smart defaults，然后应用 CLI final overrides，移除 `scene` 标记，最后进入常规 `PipelineConfig` schema normalization。
+
+```mermaid
+sequenceDiagram
+  participant Config as 配置 YAML
+  participant Loader as 配置加载器
+  participant Compiler as RunConfig 编译器
+  participant Rules as Scene 规则
+  participant CLI as CLI 覆盖
+  participant Schema as Schema 规范化
+
+  Config->>Loader: 读取 YAML 并展开环境变量
+  alt kind=RunConfig
+    Loader->>Compiler: 编译 RunConfig
+    Compiler-->>Loader: PipelineConfig payload 和可选 template path
+    Loader->>Loader: 递归物化编译后的 payload
+  end
+  Loader->>Rules: 选择 scene profile 并应用 static 规则
+  Rules-->>Loader: 返回展开后的 payload
+  Loader->>CLI: 应用 --max-samples、--metric-ids、--skip-judge
+  Loader->>Schema: 移除 scene 并规范化
+  Schema-->>Loader: PipelineConfig payload
+```
+
+规则动作的含义如下。动作列保留代码中的 action 标识，便于和 trace 或源码对应。
+
+| 动作 | 含义 |
+| --- | --- |
+| `fill` | 填写：仅当字段缺失时填入默认值。 |
+| `migrate` | 迁移：把简写字段迁移到规范字段。 |
+| `replace_subtree` | 子树替换：生成较大的配置区块，例如 `role_adapters` 或 `tasks`。 |
+| `fail` | 中止：当简写存在歧义或冲突时停止加载。 |
+
+CLI intent 可以影响最终配置：
+
+| CLI 参数 | 作用 |
+| --- | --- |
+| `--backend-id` | 仅对 static scene 生效。它会抑制 `task_backend_from_single_dut`，再由 `task_backend_expand` 将 inference 绑定到指定 backend 对应的唯一 DUT adapter。`agent` 和 `game` 当前是 no-op profile，会忽略该参数。 |
+| `--max-samples` | 在 smart defaults 之后覆盖 task `max_samples` 以及 dataset/hub limit。 |
+| `--metric-ids` | 在 smart defaults 之后过滤 metrics。 |
+| `--skip-judge` | 在 smart defaults 之后移除 `custom.steps` 和 task steps 中的 judge 步骤。 |
+
+## 4. 当前内置规则
+
+本期内置规则实现位于 static scene。阅读或扩展规则库时，建议从以下代码位置开始：
+
+| 范围 | 代码位置 |
+| --- | --- |
+| Profile 选择与 scene 分发 | [`src/gage_eval/config/smart_defaults/profiles.py`](../../src/gage_eval/config/smart_defaults/profiles.py) |
+| 规则注册与分阶段执行 | [`src/gage_eval/config/smart_defaults/registry.py`](../../src/gage_eval/config/smart_defaults/registry.py) |
+| 当前 static 规则实现 | [`src/gage_eval/config/smart_defaults/static_rules.py`](../../src/gage_eval/config/smart_defaults/static_rules.py) |
+| CLI intent 与 final overrides | [`src/gage_eval/config/loader_cli.py`](../../src/gage_eval/config/loader_cli.py) |
+| 配置加载器接入 | [`src/gage_eval/config/loader.py`](../../src/gage_eval/config/loader.py) |
+| `--show-expanded-config` 展示过滤 | [`run.py`](../../run.py) |
+
+static profile 会按以下顺序执行 phase：`dataset`、`backend`、`role_adapter`、`custom_steps`、`task`。同一 phase 内 priority 越小越先执行；priority 相同时按规则名称排序。
+
+| Phase | Priority | 规则 |
+| --- | ---: | --- |
+| `dataset` | 10 | `dataset_hub_from_hub_id` |
+| `dataset` | 10 | `dataset_loader_from_hub_id` |
+| `dataset` | 20 | `dataset_loader_from_path` |
+| `dataset` | 30 | `dataset_hub_params_gather` |
+| `dataset` | 40 | `dataset_preprocess_kwargs_default` |
+| `backend` | 10 | `litellm_api_base_from_provider` |
+| `backend` | 10 | `litellm_provider_from_api_base` |
+| `backend` | 10 | `vllm_tokenizer_path_from_model_path` |
+| `backend` | 20 | `vllm_force_tokenize_prompt_default` |
+| `backend` | 20 | `vllm_tokenizer_trust_remote_code_default` |
+| `backend` | 30 | `litellm_max_retries_default` |
+| `backend` | 30 | `litellm_streaming_default` |
+| `role_adapter` | 20 | `auto_dut_role_adapters` |
+| `custom_steps` | 20 | `auto_custom_steps` |
+| `task` | 5 | `single_task_fallback` |
+| `task` | 6 | `task_singular_alias` |
+| `task` | 10 | `task_implicit_ids` |
+| `task` | 15 | `task_backend_from_single_dut` |
+| `task` | 20 | `task_backend_expand` |
+| `task` | 30 | `task_reporting_default` |
+
+task phase 中的 priority 间隔是有意设计的：`task_backend_from_single_dut` 只在安全时填写 `task.backend`，随后 `task_backend_expand` 消费这个字段或 CLI `--backend-id`，写入实际的 inference `adapter_id`。
+
+### 4.1 Dataset 规则
+
+| 规则 | 推断或改写内容 | 示例输入 |
+| --- | --- | --- |
+| `dataset_hub_from_hub_id` | 使用 `hub_id` 简写时补齐 `hub: huggingface`。 | `hub_id: Maxwell-Jia/AIME_2024` |
+| `dataset_loader_from_hub_id` | 使用 `hub_id` 简写时补齐 `loader: hf_hub`。 | `hub_id: google/simpleqa-verified` |
+| `dataset_loader_from_path` | 从本地路径后缀推断 `loader: jsonl` 或 `loader: json`。 | `params.path: data/smoke.jsonl` |
+| `dataset_hub_params_gather` | 将 `hub_id`、`split`、`subset`、`revision`、`data_files` 迁移到 `hub_params`。 | `split: train` |
+| `dataset_preprocess_kwargs_default` | 声明 `params.preprocess` 时补齐空的 `params.preprocess_kwargs`。 | `preprocess: aime2024_preprocessor` |
+
+简化前：
+
+```yaml
+datasets:
+  - dataset_id: aime2024_ds
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+    params:
+      preprocess: aime2024_preprocessor
+```
+
+展开后：
+
+```yaml
+datasets:
+  - dataset_id: aime2024_ds
+    hub: huggingface
+    loader: hf_hub
+    hub_params:
+      hub_id: Maxwell-Jia/AIME_2024
+      split: train
+    params:
+      preprocess: aime2024_preprocessor
+      preprocess_kwargs: {}
+```
+
+### 4.2 Backend 规则
+
+| 规则 | 适用对象 | 补齐内容 |
+| --- | --- | --- |
+| `vllm_tokenizer_path_from_model_path` | `type: vllm` | 根据 `config.model_path` 补齐 `config.tokenizer_path`。 |
+| `vllm_force_tokenize_prompt_default` | `type: vllm` | 补齐 `config.force_tokenize_prompt: true`。 |
+| `vllm_tokenizer_trust_remote_code_default` | `type: vllm` | 补齐 `config.tokenizer_trust_remote_code: true`。 |
+| `litellm_provider_from_api_base` | `type: litellm` | 根据已知 API base 推断 `provider`，例如 OpenAI 或 DeepSeek。 |
+| `litellm_api_base_from_provider` | `type: litellm` | 根据已知 `provider` 补齐 `api_base`。 |
+| `litellm_streaming_default` | `type: litellm` | 补齐 `config.streaming: false`。 |
+| `litellm_max_retries_default` | `type: litellm` | 补齐 `config.max_retries: 6`。 |
+
+当前保留的两个示例配置都使用本地 OpenAI-compatible LiteLLM endpoint：
+
+```yaml
+backends:
+  - backend_id: local_qwen
+    type: litellm
+    config:
+      provider: openai
+      api_base: http://127.0.0.1:1234/v1
+      model: qwen/qwen3.5-9b
+      api_key: local
+```
+
+Backend 智能推断保持保守，不会自动推断容量、token 预算、采样参数或模型特定生成参数。运行依赖这些字段时，需要显式声明：
+
+| 字段类型 | 不会被推断的示例 |
+| --- | --- |
+| vLLM 容量与上下文 | `max_tokens`、`max_model_len`、`gpu_memory_utilization`、`async_max_concurrency` |
+| 采样控制 | `sampling_params`、`temperature`、`top_p` |
+| LiteLLM 生成参数 | `generation_parameters.max_new_tokens`、`generation_parameters.temperature` |
+| 后端特定性能开关 | 上方 static 规则表以外的 backend-specific knob |
+
+### 4.3 Role Adapter 与 Step 规则
+
+| 规则 | 作用 | 生效条件 |
+| --- | --- | --- |
+| `auto_dut_role_adapters` | 为每个 backend 生成 `dut_<backend_id>`，capability 为 `chat_completion`。 | 仅当 `role_adapters` 缺失时。 |
+| `auto_custom_steps` | 生成 `inference -> auto_eval`。 | 仅当全部 adapter 都是 DUT，且 `custom.steps` 缺失时。 |
+
+纯 DUT 配置可以省略 `role_adapters` 和 `custom.steps`：
+
+```mermaid
+flowchart LR
+  Backend["backend_id: local_qwen"] --> Adapter["dut_local_qwen"]
+  Adapter --> Inference["inference"]
+  Inference --> Eval["auto_eval"]
+  classDef config fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef inferred fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  classDef run fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  class Backend config;
+  class Adapter inferred;
+  class Inference,Eval run;
+```
+
+包含 judge 的配置仍应显式声明 judge adapter 和 judge step。SimpleQA Verified 示例就是这种情况：一个本地 backend 同时承担 DUT 和 judge 两个角色。
+
+### 4.4 Task 规则
+
+| 规则 | 作用 |
+| --- | --- |
+| `single_task_fallback` | 当且仅当存在一个 dataset 和一个 DUT adapter，且没有 `task`/`tasks` 时，生成单任务。 |
+| `task_singular_alias` | 将顶层 `task:` 转换为单元素 `tasks:` 列表。 |
+| `task_implicit_ids` | 使用 `metadata.name` 补齐 `task_id`，并在唯一 dataset 场景下补齐 `dataset_id`。 |
+| `task_backend_from_single_dut` | 当且仅当存在唯一 DUT adapter 且没有 CLI backend override 时，补齐 `task.backend`。 |
+| `task_backend_expand` | 将 `task.backend` 或 `--backend-id` 转换为 inference step 的 `adapter_id` 绑定。 |
+| `task_reporting_default` | 补齐标准 console/file reporting sinks。 |
+
+存在歧义时会 fail fast。例如：如果配置有多个 dataset，则 task 不能省略 `dataset_id`。
+
+## 5. 示例介绍
+
+### 5.1 AIME 2024：纯 DUT static 配置
+
+AIME 2024 简化配置只保留 dataset、backend 和 metric。文档索引中链接的 YAML 文件是配置源，下面片段只保留与智能推断相关的字段，省略不改变简化行为的普通 metadata 或生成参数。
+
+```yaml
+scene: static
+metadata:
+  name: aime2024_simple_static
+
+datasets:
+  - dataset_id: aime2024_ds
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+    params:
+      preprocess: aime2024_preprocessor
+
+backends:
+  - backend_id: local_qwen
+    type: litellm
+    config:
+      provider: openai
+      api_base: http://127.0.0.1:1234/v1
+      model: qwen/qwen3.5-9b
+      api_key: local
+
+metrics:
+  - metric_id: aime2024_acc
+    implementation: aime2024_accuracy
+```
+
+static 规则会推断：
+
+- Hugging Face dataset loader 接线；
+- LiteLLM retry 与 streaming 默认值；
+- `dut_local_qwen`；
+- `inference -> auto_eval`；
+- 名为 `aime2024_simple_static` 的单任务；
+- 标准 report sinks。
+
+执行：
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --max-samples 10 \
+  --run-id aime2024_static_smoke
+```
+
+查看展开结果：
+
+```bash
+python run.py \
+  --config config/custom/aime24/aime2024_simple_static.yaml \
+  --show-expanded-config
+```
+
+### 5.2 SimpleQA Verified：DUT + Judge static 配置
+
+SimpleQA Verified 需要 judge step，因此简化配置仍然显式声明：
+
+- `custom.steps`：因为流水线是 `inference -> judge -> auto_eval`；
+- `prompts`：因为 judge 需要评分提示词；
+- `role_adapters`：因为同一个 `local_qwen` backend 同时作为 DUT 和 judge。
+
+```mermaid
+flowchart LR
+  Dataset["google/simpleqa-verified"] --> Inference["DUT inference"]
+  Inference --> Judge["judge_local_qwen"]
+  Judge --> Eval["auto_eval metrics"]
+  Backend["local_qwen LiteLLM"] --> Inference
+  Backend --> Judge
+  classDef data fill:#E8F3FF,stroke:#2F80ED,color:#143A5A;
+  classDef backend fill:#FFF4D6,stroke:#F2A900,color:#5A3B00;
+  classDef step fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67;
+  classDef output fill:#E9F8EF,stroke:#27AE60,color:#174A2A;
+  class Dataset data;
+  class Backend backend;
+  class Inference,Judge step;
+  class Eval output;
+```
+
+执行：
+
+```bash
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --max-samples 10 \
+  --run-id simpleqa_verified_static_smoke
+```
+
+常用变体：
+
+```bash
+# 查看完整展开配置
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --show-expanded-config
+
+# 只保留一个 metric
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --metric-ids simpleqa_verified_acc \
+  --max-samples 10 \
+  --run-id simpleqa_verified_acc_only
+
+# 运行时跳过 judge step
+python run.py \
+  --config config/custom/simpleqa_verified/simpleqa_verified_simple_static.yaml \
+  --skip-judge \
+  --max-samples 10 \
+  --run-id simpleqa_verified_no_judge
+```
+
+## 6. 常见错误与修复指引
+
+智能推断错误会以 `SmartDefaultsError` 抛出；当规则能够定位字段时，错误信息会带上路径。
+
+| 错误文本 | 常见原因 | 修复方式 |
+| --- | --- | --- |
+| `Unknown PipelineConfig scene 'research'` | `scene` 不是已识别的场景名称。 | 使用 `scene: static`、`scene: agent`、`scene: game`，或删除 `scene` 回到 legacy 行为。 |
+| `task and tasks cannot both be declared` | 同时声明了单数快捷写法和规范任务列表。 | 单任务保留 `task:`，任务列表保留 `tasks:`，二者只能选一个。 |
+| `task omitted dataset_id but config does not have exactly one dataset at tasks[0]` | task 省略 `dataset_id`，但配置里有多个 dataset。 | 为每个需要绑定数据集的 task 显式补齐 `dataset_id`。 |
+| `task omitted backend but config does not have exactly one DUT adapter at tasks[0]` | task 省略 `backend`，但无法从唯一 DUT adapter 推断 inference 目标。 | 补齐 `task.backend`，传入 `--backend-id`，或让 `role_adapters` 变得唯一。 |
+| `cannot find unique DUT adapter for backend 'local_qwen' at cli.backend_id` | `--backend-id` 或 `task.backend` 指向了 0 个或多个 DUT adapter。 | 检查 backend id，并确保只有一个 `role_type: dut_model` adapter 使用该 backend。 |
+| `task must have exactly one inference step to bind backend at tasks[0].steps` | backend 绑定需要修改 inference step，但 task 中没有或存在多个 `step: inference`。 | 在 `custom.steps` 或 task 自身 `steps` 中保留一个 inference step。 |
+
+## 7. 何时保持显式配置
+
+当配置是常规 static benchmark，且 inference 接线明确时，适合使用简化形式。
+
+当规则库必须猜测时，应保持显式：
+
+- 存在多个 dataset，且不同 task 需要绑定不同 dataset；
+- 存在多个 DUT adapter，无法唯一推断 inference 目标；除非 task 或 adapter 配置消除歧义，否则这是硬失败；
+- 流水线包含 judge、support、自定义后处理或非标准 report sinks；
+- backend type 没有被当前 scene 规则覆盖；
+- 正在编写 `agent` 或 `game` scene 配置。
+
+推荐工作流是：先写简化配置，再运行 `--show-expanded-config`，确认推断结果清楚、可审阅后再执行真实评测。

--- a/run.py
+++ b/run.py
@@ -28,6 +28,13 @@ if str(SRC_ROOT) not in sys.path:
 
 import gage_eval  # noqa: F401 - auto-discovery happens on import
 from gage_eval.config import build_default_registry
+from gage_eval.config.loader import (
+    expand_env as _loader_expand_env,
+    load_pipeline_config_payload,
+    load_pre_smart_defaults_payload,
+    load_yaml_mapping,
+)
+from gage_eval.config.loader_cli import CLIIntent, apply_cli_final_overrides, parse_metric_ids_csv
 from gage_eval.tools.distill import DistillError, analyze_tasks_for_distill
 from gage_eval.config.pipeline_config import PipelineConfig
 from gage_eval.evaluation.runtime_builder import build_runtime
@@ -94,6 +101,20 @@ def parse_args() -> argparse.Namespace:
         help="Skip the judge step by removing it from custom.steps at runtime.",
     )
     parser.add_argument(
+        "--show-expanded-config",
+        action="store_true",
+        help="Print the smart-default-expanded PipelineConfig payload and exit.",
+    )
+    parser.add_argument(
+        "--no-smart-defaults",
+        action="store_true",
+        help="Disable smart defaults when loading PipelineConfig YAML.",
+    )
+    parser.add_argument(
+        "--backend-id",
+        help="Override the static DUT backend used for inference binding.",
+    )
+    parser.add_argument(
         "--distill",
         "-d",
         action="store_true",
@@ -140,23 +161,12 @@ def parse_args() -> argparse.Namespace:
 
 def _apply_cli_metric_filter(payload: dict, metric_ids_csv: str) -> None:
     """Filter payload metrics by metric_id (in-place)."""
-    wanted = {m.strip() for m in (metric_ids_csv or "").split(",") if m.strip()}
-    if not wanted:
-        return
-    metrics = payload.get("metrics") or []
-    if isinstance(metrics, list):
-        payload["metrics"] = [m for m in metrics if isinstance(m, dict) and m.get("metric_id") in wanted]
+    apply_cli_final_overrides(payload, CLIIntent(metric_ids=parse_metric_ids_csv(metric_ids_csv)))
 
 
 def _apply_cli_skip_judge(payload: dict) -> None:
-    """Remove judge step from payload custom.steps (in-place)."""
-    custom = payload.get("custom")
-    if not isinstance(custom, dict):
-        return
-    steps = custom.get("steps")
-    if not isinstance(steps, list):
-        return
-    custom["steps"] = [s for s in steps if not (isinstance(s, dict) and s.get("step") == "judge")]
+    """Remove judge steps from payload custom and task steps (in-place)."""
+    apply_cli_final_overrides(payload, CLIIntent(skip_judge=True))
 
 
 def _normalize_version_tag(version: str) -> str:
@@ -183,46 +193,20 @@ def _ensure_spawn_start_method() -> None:
 
 
 def load_config(path: Path) -> dict:
-    if not path.exists():
-        raise FileNotFoundError(f"Config file '{path}' not found")
-    with path.open("r", encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
-    if not isinstance(data, dict):
-        raise ValueError(f"Config '{path}' must be a mapping at the top level")
-    return _expand_env(data)
-
-
-_ENV_PATTERN = re.compile(r"^\$\{([^}:]+)(?:(:-|:\?)(.*))?\}$")
+    return _loader_expand_env(load_yaml_mapping(path))
 
 
 def _expand_env(value):
-    """Recursively expand ${VAR:-default} and ${VAR:?message} in YAML configs."""
+    return _loader_expand_env(value)
 
-    if isinstance(value, dict):
-        return {k: _expand_env(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_expand_env(v) for v in value]
-    if isinstance(value, str):
-        match = _ENV_PATTERN.match(value.strip())
-        if not match:
-            return value
-        var, operator, operand = match.group(1), match.group(2), match.group(3)
-        if operator == ":?" and not os.getenv(var):
-            message = operand or f"environment variable {var} is required"
-            raise ValueError(message)
-        resolved = os.getenv(var, operand if operator == ":-" and operand is not None else "")
-        # NOTE: Attempt to cast pure numeric strings to int/float to avoid type
-        # errors in downstream comparisons (for example: max_samples).
-        if isinstance(resolved, str) and resolved.strip():
-            try:
-                return int(resolved)
-            except ValueError:
-                try:
-                    return float(resolved)
-                except ValueError:
-                    return resolved
-        return resolved
-    return value
+
+def _build_cli_intent(args: argparse.Namespace) -> CLIIntent:
+    return CLIIntent(
+        backend_id=args.backend_id,
+        max_samples=args.max_samples,
+        skip_judge=args.skip_judge,
+        metric_ids=parse_metric_ids_csv(args.metric_ids),
+    )
 
 
 class _LiteralDumper(yaml.SafeDumper):
@@ -245,11 +229,38 @@ def _str_representer(dumper: yaml.SafeDumper, data: str):
 _LiteralDumper.add_representer(str, _str_representer)
 
 
+def _yaml_dump(data: dict, *, sort_keys: bool = False) -> str:
+    content = yaml.dump(
+        data,
+        Dumper=_LiteralDumper,
+        sort_keys=sort_keys,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
+    return _insert_top_level_spacing(content)
+
+
+_EMPTY_EXPANDED_CONFIG_DISPLAY_SECTIONS = {
+    "models",
+    "agent_backends",
+    "sandbox_profiles",
+    "mcp_clients",
+    "prompts",
+    "summary_generators",
+}
+
+
+def _hide_empty_expanded_config_sections(payload: dict) -> dict:
+    display_payload = dict(payload)
+    for key in _EMPTY_EXPANDED_CONFIG_DISPLAY_SECTIONS:
+        if display_payload.get(key) == []:
+            display_payload.pop(key)
+    return display_payload
+
+
 def _write_yaml(data: dict, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    content = yaml.dump(data, Dumper=_LiteralDumper, sort_keys=False, allow_unicode=True, default_flow_style=False)
-    content = _insert_top_level_spacing(content)
-    path.write_text(content, encoding="utf-8")
+    path.write_text(_yaml_dump(data, sort_keys=False), encoding="utf-8")
 
 
 def _dedupe_path(path: Path) -> Path:
@@ -1150,6 +1161,7 @@ def _validate_config_wiring_with_registry(config: PipelineConfig, asset_registry
 def main() -> None:
     wall_clock_start = time.perf_counter()
     args = parse_args()
+    cli_intent = _build_cli_intent(args)
     if sys.stdin.isatty() and os.environ.get("GAGE_EVAL_HUMAN_INPUT") is None:
         os.environ["GAGE_EVAL_HUMAN_INPUT"] = "stdin"
 
@@ -1161,9 +1173,39 @@ def main() -> None:
             sys.exit(1)
         sys.exit(0)
 
+    if args.show_expanded_config:
+        try:
+            config_path = Path(args.config).expanduser()
+            if args.no_smart_defaults:
+                payload = load_pre_smart_defaults_payload(
+                    config_path,
+                    run_config_compiler=_compile_run_config,
+                )
+            else:
+                payload = load_pipeline_config_payload(
+                    config_path,
+                    cli_intent=cli_intent,
+                    smart_defaults=True,
+                    run_config_compiler=_compile_run_config,
+                )
+        except Exception as exc:
+            print(f"[gage-eval] failed to expand config: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print(_yaml_dump(_hide_empty_expanded_config_sections(payload), sort_keys=False))
+        sys.exit(0)
+
     if args.distill:
         builtin_name = args.builtin_name
-        config_payload = load_config(Path(args.config).expanduser())
+        try:
+            config_payload = load_pipeline_config_payload(
+                Path(args.config).expanduser(),
+                cli_intent=cli_intent,
+                smart_defaults=not args.no_smart_defaults,
+                run_config_compiler=_compile_run_config,
+            )
+        except Exception as exc:
+            print(f"[gage-eval][distill] {exc}", file=sys.stderr)
+            sys.exit(1)
         if not builtin_name and args.distill_output:
             # NOTE: If distill_output is provided without builtin_name, use the last
             # path component as the template name.
@@ -1225,31 +1267,18 @@ def main() -> None:
     if args.model_path:
         os.environ["VLLM_NATIVE_MODEL_PATH"] = args.model_path
     _install_signal_handlers()
-    config_payload = load_config(Path(args.config).expanduser())
     config_source_desc = args.config
-    raw_kind = (config_payload.get("kind") or "").lower()
-    if raw_kind == "runconfig":
-        try:
-            compiled_payload, template_path = _compile_run_config(config_payload)
-        except Exception as exc:
-            print(f"[gage-eval][runconfig] {exc}", file=sys.stderr)
-            sys.exit(1)
-        if args.max_samples is not None:
-            _apply_cli_max_samples_override(compiled_payload, args.max_samples)
-        if args.metric_ids:
-            _apply_cli_metric_filter(compiled_payload, args.metric_ids)
-        if args.skip_judge:
-            _apply_cli_skip_judge(compiled_payload)
-        config = PipelineConfig.from_dict(compiled_payload)
-        config_source_desc = f"{args.config} (template: {template_path})"
-    else:
-        if args.max_samples is not None:
-            _apply_cli_max_samples_override(config_payload, args.max_samples)
-        if args.metric_ids:
-            _apply_cli_metric_filter(config_payload, args.metric_ids)
-        if args.skip_judge:
-            _apply_cli_skip_judge(config_payload)
-        config = PipelineConfig.from_dict(config_payload)
+    try:
+        materialized = load_pipeline_config_payload(
+            Path(args.config).expanduser(),
+            cli_intent=cli_intent,
+            smart_defaults=not args.no_smart_defaults,
+            run_config_compiler=_compile_run_config,
+        )
+    except Exception as exc:
+        print(f"[gage-eval] failed to load config: {exc}", file=sys.stderr)
+        sys.exit(1)
+    config = PipelineConfig.from_dict(materialized)
 
     registry = build_default_registry()
 

--- a/src/gage_eval/config/__init__.py
+++ b/src/gage_eval/config/__init__.py
@@ -5,9 +5,24 @@ from __future__ import annotations
 import importlib
 from typing import Iterable
 
+from gage_eval.config.loader import (
+    expand_env,
+    load_yaml_mapping,
+    load_pipeline_config_payload,
+    load_pre_smart_defaults_payload,
+    materialize_pipeline_config_payload,
+)
 from gage_eval.config.registry import ConfigRegistry
 
-__all__ = ["ConfigRegistry", "build_default_registry"]
+__all__ = [
+    "ConfigRegistry",
+    "build_default_registry",
+    "expand_env",
+    "load_yaml_mapping",
+    "load_pipeline_config_payload",
+    "load_pre_smart_defaults_payload",
+    "materialize_pipeline_config_payload",
+]
 
 
 def build_default_registry(plugin_modules: Iterable[str] | None = None) -> ConfigRegistry:

--- a/src/gage_eval/config/loader.py
+++ b/src/gage_eval/config/loader.py
@@ -1,0 +1,148 @@
+"""Helpers for loading and materializing configuration payloads."""
+
+from __future__ import annotations
+
+import os
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Callable, TypeAlias
+
+import yaml
+
+from gage_eval.config.loader_cli import CLIIntent, apply_cli_final_overrides
+from gage_eval.config.schema import normalize_pipeline_payload
+from gage_eval.config.smart_defaults.registry import apply_smart_defaults
+from gage_eval.config.smart_defaults.profiles import select_smart_defaults_profile
+from gage_eval.config.smart_defaults.types import RuleContext
+
+RunConfigCompiler: TypeAlias = Callable[[dict[str, Any]], tuple[dict[str, Any], Path | None]]
+
+_ENV_PATTERN = re.compile(r"^\$\{([^}:]+)(?:(:-|:\?)(.*))?\}$")
+_MAX_RUNCONFIG_DEPTH = 32
+
+
+def load_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Load a YAML file and require a mapping at the top level."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Config file '{path}' not found")
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Config '{path}' must be a mapping at the top level")
+    return data
+
+
+def expand_env(value: Any) -> Any:
+    """Recursively expand whole-string environment placeholders in a payload."""
+
+    if isinstance(value, dict):
+        return {key: expand_env(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [expand_env(item) for item in value]
+    if isinstance(value, str):
+        match = _ENV_PATTERN.match(value)
+        if not match:
+            return value
+        var, operator, operand = match.group(1), match.group(2), match.group(3)
+        if operator == ":?" and not os.getenv(var):
+            raise ValueError(operand or f"environment variable {var} is required")
+        resolved = os.getenv(var, operand if operator == ":-" and operand is not None else "")
+        if isinstance(resolved, str) and resolved.strip():
+            try:
+                return int(resolved)
+            except ValueError:
+                try:
+                    return float(resolved)
+                except ValueError:
+                    return resolved
+        return resolved
+    return value
+
+
+def materialize_pipeline_config_payload(
+    payload: dict[str, Any],
+    source_path: Path | None,
+    run_config_compiler: RunConfigCompiler | None = None,
+    *,
+    cli_intent: CLIIntent | None = None,
+    smart_defaults: bool = True,
+) -> dict[str, Any]:
+    """Expand env vars, compile RunConfig payloads, and normalize PipelineConfig payloads."""
+
+    materialized = _materialize_payload(payload, source_path, run_config_compiler)
+    intent = cli_intent or CLIIntent()
+    if smart_defaults:
+        materialized = _apply_smart_defaults(materialized, source_path, intent)
+    apply_cli_final_overrides(materialized, intent)
+    materialized.pop("scene", None)
+    return normalize_pipeline_payload(materialized)
+
+
+def load_pipeline_config_payload(
+    path: Path,
+    run_config_compiler: RunConfigCompiler | None = None,
+    *,
+    cli_intent: CLIIntent | None = None,
+    smart_defaults: bool = True,
+) -> dict[str, Any]:
+    """Load a PipelineConfig payload from YAML and fully materialize it."""
+
+    return materialize_pipeline_config_payload(
+        load_yaml_mapping(path),
+        path,
+        run_config_compiler,
+        cli_intent=cli_intent,
+        smart_defaults=smart_defaults,
+    )
+
+
+def load_pre_smart_defaults_payload(
+    path: Path,
+    run_config_compiler: RunConfigCompiler | None = None,
+) -> dict[str, Any]:
+    """Load a payload for pre-smart-defaults flows without schema normalization."""
+
+    materialized = _materialize_payload(load_yaml_mapping(path), path, run_config_compiler)
+    select_smart_defaults_profile(materialized, path)
+    return materialized
+
+
+def _materialize_payload(
+    payload: dict[str, Any],
+    source_path: Path | None,
+    run_config_compiler: RunConfigCompiler | None,
+    _depth: int = 0,
+) -> dict[str, Any]:
+    materialized = expand_env(deepcopy(payload))
+    kind = str(materialized.get("kind") or "")
+    if kind.lower() == "runconfig":
+        if run_config_compiler is None:
+            raise ValueError("RunConfig payload requires run_config_compiler")
+        if _depth >= _MAX_RUNCONFIG_DEPTH:
+            source_hint = f" for '{source_path}'" if source_path is not None else ""
+            raise ValueError(
+                f"RunConfig materialization exceeded {_MAX_RUNCONFIG_DEPTH} nested compilations{source_hint}"
+            )
+        compiled_payload, template_path = run_config_compiler(deepcopy(materialized))
+        next_source_path = template_path or source_path
+        return _materialize_payload(
+            compiled_payload,
+            next_source_path,
+            run_config_compiler,
+            _depth=_depth + 1,
+        )
+    return materialized
+
+
+def _apply_smart_defaults(
+    payload: dict[str, Any],
+    source_path: Path | None,
+    cli_intent: CLIIntent,
+) -> dict[str, Any]:
+    profile = select_smart_defaults_profile(payload, source_path)
+    if not profile.rules:
+        return payload
+    ctx = RuleContext(source_path=source_path, cli_intent=cli_intent, scene=profile.scene)
+    return apply_smart_defaults(payload, ctx, profile)

--- a/src/gage_eval/config/loader_cli.py
+++ b/src/gage_eval/config/loader_cli.py
@@ -1,0 +1,103 @@
+"""CLI intent types shared by config loading and smart defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CLIIntent:
+    """Read-only CLI options that influence config materialization."""
+
+    backend_id: str | None = None
+    max_samples: int | None = None
+    skip_judge: bool = False
+    metric_ids: tuple[str, ...] | None = None
+
+
+def parse_metric_ids_csv(metric_ids_csv: str | None) -> tuple[str, ...] | None:
+    """Parse a comma-separated metric id list from CLI input."""
+
+    if not metric_ids_csv:
+        return None
+    parsed = tuple(item.strip() for item in metric_ids_csv.split(",") if item.strip())
+    return parsed or None
+
+
+def apply_cli_final_overrides(payload: dict[str, Any], intent: CLIIntent) -> None:
+    """Apply CLI overrides to an already materialized PipelineConfig payload."""
+
+    if intent.max_samples is not None:
+        _apply_max_samples(payload, intent.max_samples)
+    if intent.metric_ids:
+        _apply_metric_filter(payload, set(intent.metric_ids))
+    if intent.skip_judge:
+        _apply_skip_judge(payload)
+
+
+def _apply_max_samples(payload: dict[str, Any], max_samples: int) -> None:
+    for task in payload.get("tasks") or []:
+        if isinstance(task, dict):
+            task["max_samples"] = max_samples
+
+    for dataset in payload.get("datasets") or []:
+        if not isinstance(dataset, dict):
+            continue
+        params = dataset.get("params")
+        if isinstance(params, dict):
+            params["limit"] = max_samples
+        hub_params = dataset.get("hub_params")
+        if isinstance(hub_params, dict):
+            hub_params["limit"] = max_samples
+
+
+def _apply_metric_filter(payload: dict[str, Any], wanted: set[str]) -> None:
+    metrics = payload.get("metrics")
+    if metrics is None:
+        return
+    if not isinstance(metrics, list):
+        return
+
+    filtered = []
+    for metric in metrics:
+        metric_id = _metric_id_from_entry(metric)
+        if metric_id is None or metric_id in wanted:
+            filtered.append(metric)
+    payload["metrics"] = filtered
+
+
+def _metric_id_from_entry(entry: Any) -> str | None:
+    """Extract a metric id from documented PipelineConfig metric entry forms."""
+
+    if isinstance(entry, str):
+        metric_id = entry.split("(", 1)[0].strip()
+        return metric_id or None
+
+    if isinstance(entry, dict):
+        if len(entry) == 1 and "metric_id" not in entry and "implementation" not in entry:
+            metric_id = next(iter(entry.keys()))
+            return str(metric_id) if metric_id else None
+
+        # Compatibility fallback: single-key {"implementation": "..."} resolves
+        # to implementation, but this is not a documented CLI filter shortcut.
+        metric_id = entry.get("metric_id") or entry.get("implementation")
+        return str(metric_id) if metric_id else None
+
+    return None
+
+
+def _apply_skip_judge(payload: dict[str, Any]) -> None:
+    custom = payload.get("custom")
+    if isinstance(custom, dict) and "steps" in custom:
+        custom["steps"] = _remove_judge_steps(custom.get("steps"))
+
+    for task in payload.get("tasks") or []:
+        if isinstance(task, dict) and "steps" in task:
+            task["steps"] = _remove_judge_steps(task.get("steps"))
+
+
+def _remove_judge_steps(steps: Any) -> Any:
+    if not isinstance(steps, list):
+        return steps
+    return [step for step in steps if not (isinstance(step, dict) and step.get("step") == "judge")]

--- a/src/gage_eval/config/smart_defaults/__init__.py
+++ b/src/gage_eval/config/smart_defaults/__init__.py
@@ -1,0 +1,25 @@
+"""Smart-default rule framework."""
+
+from __future__ import annotations
+
+from gage_eval.config.smart_defaults.profiles import STATIC_PHASES, select_smart_defaults_profile
+from gage_eval.config.smart_defaults.registry import apply_smart_defaults, smart_default
+from gage_eval.config.smart_defaults.types import (
+    DefaultTrace,
+    RuleContext,
+    SmartDefaultRule,
+    SmartDefaultsError,
+    SmartDefaultsProfile,
+)
+
+__all__ = [
+    "DefaultTrace",
+    "RuleContext",
+    "SmartDefaultRule",
+    "SmartDefaultsError",
+    "SmartDefaultsProfile",
+    "STATIC_PHASES",
+    "apply_smart_defaults",
+    "select_smart_defaults_profile",
+    "smart_default",
+]

--- a/src/gage_eval/config/smart_defaults/profiles.py
+++ b/src/gage_eval/config/smart_defaults/profiles.py
@@ -1,0 +1,34 @@
+"""Smart-default profile selection for pipeline payloads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import gage_eval.config.smart_defaults.static_rules as _static_rules  # noqa: F401
+from gage_eval.config.smart_defaults.registry import registered_rules
+from gage_eval.config.smart_defaults.types import SceneName, SmartDefaultsError, SmartDefaultsProfile
+
+STATIC_PHASES: tuple[str, ...] = ("dataset", "backend", "role_adapter", "custom_steps", "task")
+_NOOP_PHASES: tuple[str, ...] = ()
+_KNOWN_SCENES = {"static", "agent", "game"}
+
+
+def select_smart_defaults_profile(payload: dict[str, Any], source_path: Path | None) -> SmartDefaultsProfile:
+    """Select the smart-default profile for a raw config payload."""
+
+    kind = str(payload.get("kind") or "PipelineConfig").lower()
+    if kind != "pipelineconfig":
+        return SmartDefaultsProfile(scene="legacy", phases=_NOOP_PHASES, rules=())
+
+    scene_value = payload.get("scene")
+    if scene_value is None:
+        return SmartDefaultsProfile(scene="legacy", phases=_NOOP_PHASES, rules=())
+
+    scene = str(scene_value).strip().lower()
+    if scene not in _KNOWN_SCENES:
+        raise SmartDefaultsError(f"Unknown PipelineConfig scene '{scene_value}'")
+    if scene != "static":
+        return SmartDefaultsProfile(scene=scene, phases=_NOOP_PHASES, rules=())
+
+    return SmartDefaultsProfile(scene="static", phases=STATIC_PHASES, rules=registered_rules("static"))

--- a/src/gage_eval/config/smart_defaults/registry.py
+++ b/src/gage_eval/config/smart_defaults/registry.py
@@ -1,0 +1,83 @@
+"""Registration and execution helpers for smart-default rules."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Callable
+
+from gage_eval.config.smart_defaults.types import (
+    RuleContext,
+    SceneName,
+    SmartDefaultRule,
+    SmartDefaultsError,
+    SmartDefaultsProfile,
+)
+
+_RULES: list[SmartDefaultRule] = []
+
+
+def _rule_key(rule: SmartDefaultRule) -> tuple[SceneName, str, str]:
+    return (rule.scene, rule.phase, rule.name)
+
+
+def smart_default(
+    *,
+    scene: SceneName,
+    phase: str,
+    priority: int = 0,
+    name: str | None = None,
+    description: str,
+) -> Callable[[Callable[[dict[str, Any], RuleContext], None]], Callable[[dict[str, Any], RuleContext], None]]:
+    """Register a smart-default rule for a scene and phase."""
+
+    def decorator(func: Callable[[dict[str, Any], RuleContext], None]) -> Callable[[dict[str, Any], RuleContext], None]:
+        rule = SmartDefaultRule(
+            scene=scene,
+            phase=phase,
+            priority=priority,
+            name=name or func.__name__,
+            description=description,
+            apply=func,
+        )
+        rule_key = _rule_key(rule)
+        for index, existing_rule in enumerate(_RULES):
+            if _rule_key(existing_rule) == rule_key:
+                _RULES[index] = rule
+                _RULES[:] = [
+                    candidate
+                    for candidate_index, candidate in enumerate(_RULES)
+                    if candidate_index <= index or _rule_key(candidate) != rule_key
+                ]
+                return func
+        _RULES.append(rule)
+        return func
+
+    return decorator
+
+
+def registered_rules(scene: SceneName | None = None) -> tuple[SmartDefaultRule, ...]:
+    """Return registered rules, optionally filtered by scene."""
+
+    rules = _RULES if scene is None else [rule for rule in _RULES if rule.scene == scene]
+    return tuple(sorted(rules, key=lambda rule: (rule.priority, rule.name)))
+
+
+def apply_smart_defaults(payload: dict[str, Any], ctx: RuleContext, profile: SmartDefaultsProfile) -> dict[str, Any]:
+    """Apply smart-default rules to a payload copy using the caller's context."""
+
+    expanded = deepcopy(payload)
+    rules_by_phase: dict[str, list[SmartDefaultRule]] = {}
+    for rule in profile.rules:
+        rules_by_phase.setdefault(rule.phase, []).append(rule)
+
+    for phase in profile.phases:
+        phase_rules = sorted(rules_by_phase.get(phase, ()), key=lambda rule: (rule.priority, rule.name))
+        for rule in phase_rules:
+            ctx.current_rule = rule.name
+            try:
+                rule.apply(expanded, ctx)
+            except SmartDefaultsError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive wrapper
+                raise SmartDefaultsError(str(exc)) from exc
+    return expanded

--- a/src/gage_eval/config/smart_defaults/static_rules.py
+++ b/src/gage_eval/config/smart_defaults/static_rules.py
@@ -1,0 +1,525 @@
+"""Static-evaluation smart-default rules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from gage_eval.config.smart_defaults.registry import smart_default
+from gage_eval.config.smart_defaults.types import DefaultTrace, RuleContext
+
+_DATASET_HUB_PARAM_KEYS = ("hub_id", "split", "subset", "revision", "data_files")
+_LITELLM_API_BASES = {
+    "openai": "https://api.openai.com/v1",
+    "deepseek": "https://api.deepseek.com/v1",
+}
+
+
+def _iter_indexed_dicts(value: Any) -> Iterator[tuple[int, dict[str, Any]]]:
+    if not isinstance(value, list):
+        return
+    for index, item in enumerate(value):
+        if isinstance(item, dict):
+            yield index, item
+
+
+def _iter_dicts(value: Any) -> Iterator[dict[str, Any]]:
+    for _, item in _iter_indexed_dicts(value):
+        yield item
+
+
+def _backend_ids(payload: dict[str, Any]) -> list[str]:
+    return [
+        str(item.get("backend_id"))
+        for item in _iter_dicts(payload.get("backends"))
+        if item.get("backend_id")
+    ]
+
+
+def _metadata_name(payload: dict[str, Any]) -> str:
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+    return str(metadata.get("name") or "static_task")
+
+
+@smart_default(
+    scene="static",
+    phase="dataset",
+    priority=10,
+    name="dataset_hub_from_hub_id",
+    description="Fill dataset.hub when dataset.hub_id is used as sugar.",
+)
+def dataset_hub_from_hub_id(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, dataset in _iter_indexed_dicts(payload.get("datasets")):
+        if dataset.get("hub_id"):
+            ctx.fill(dataset, key="hub", value="huggingface", path=f"datasets[{index}].hub")
+
+
+@smart_default(
+    scene="static",
+    phase="dataset",
+    priority=10,
+    name="dataset_loader_from_hub_id",
+    description="Fill dataset.loader=hf_hub when dataset.hub_id is used as sugar.",
+)
+def dataset_loader_from_hub_id(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, dataset in _iter_indexed_dicts(payload.get("datasets")):
+        if dataset.get("hub_id"):
+            ctx.fill(dataset, key="loader", value="hf_hub", path=f"datasets[{index}].loader")
+
+
+@smart_default(
+    scene="static",
+    phase="dataset",
+    priority=20,
+    name="dataset_loader_from_path",
+    description="Infer json/jsonl loader from local dataset path.",
+)
+def dataset_loader_from_path(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, dataset in _iter_indexed_dicts(payload.get("datasets")):
+        if dataset.get("loader"):
+            continue
+        params = dataset.get("params") if isinstance(dataset.get("params"), dict) else {}
+        raw_path = dataset.get("path") or params.get("path")
+        if not raw_path:
+            continue
+        suffix = Path(str(raw_path)).suffix.lower()
+        if suffix == ".jsonl":
+            ctx.fill(dataset, key="loader", value="jsonl", path=f"datasets[{index}].loader")
+        elif suffix == ".json":
+            ctx.fill(dataset, key="loader", value="json", path=f"datasets[{index}].loader")
+
+
+@smart_default(
+    scene="static",
+    phase="dataset",
+    priority=30,
+    name="dataset_hub_params_gather",
+    description="Move dataset hub sugar keys into hub_params.",
+)
+def dataset_hub_params_gather(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, dataset in _iter_indexed_dicts(payload.get("datasets")):
+        present_keys = [key for key in _DATASET_HUB_PARAM_KEYS if key in dataset]
+        if not present_keys:
+            continue
+
+        hub_params = dataset.get("hub_params")
+        if hub_params is None:
+            hub_params = {}
+            dataset["hub_params"] = hub_params
+        if not isinstance(hub_params, dict):
+            ctx.fail("dataset.hub_params must be a mapping", path=f"datasets[{index}].hub_params")
+
+        for key in present_keys:
+            ctx.migrate(
+                dataset,
+                source_key=key,
+                target=hub_params,
+                target_key=key,
+                path=f"datasets[{index}].hub_params.{key}",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="dataset",
+    priority=40,
+    name="dataset_preprocess_kwargs_default",
+    description="Fill params.preprocess_kwargs when params.preprocess is declared.",
+)
+def dataset_preprocess_kwargs_default(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, dataset in _iter_indexed_dicts(payload.get("datasets")):
+        params = dataset.get("params")
+        if isinstance(params, dict) and params.get("preprocess"):
+            ctx.fill(
+                params,
+                key="preprocess_kwargs",
+                value={},
+                path=f"datasets[{index}].params.preprocess_kwargs",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=10,
+    name="vllm_tokenizer_path_from_model_path",
+    description="Fill tokenizer_path from model_path for vLLM configs.",
+)
+def vllm_tokenizer_path_from_model_path(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") != "vllm" or not isinstance(backend.get("config"), dict):
+            continue
+        config = backend["config"]
+        if config.get("model_path"):
+            ctx.fill(
+                config,
+                key="tokenizer_path",
+                value=config["model_path"],
+                path=f"backends[{index}].config.tokenizer_path",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=20,
+    name="vllm_force_tokenize_prompt_default",
+    description="Fill vLLM force_tokenize_prompt default.",
+)
+def vllm_force_tokenize_prompt_default(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") == "vllm" and isinstance(backend.get("config"), dict):
+            ctx.fill(
+                backend["config"],
+                key="force_tokenize_prompt",
+                value=True,
+                path=f"backends[{index}].config.force_tokenize_prompt",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=20,
+    name="vllm_tokenizer_trust_remote_code_default",
+    description="Fill vLLM tokenizer_trust_remote_code default.",
+)
+def vllm_tokenizer_trust_remote_code_default(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") == "vllm" and isinstance(backend.get("config"), dict):
+            ctx.fill(
+                backend["config"],
+                key="tokenizer_trust_remote_code",
+                value=True,
+                path=f"backends[{index}].config.tokenizer_trust_remote_code",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=10,
+    name="litellm_provider_from_api_base",
+    description="Infer LiteLLM provider from api_base.",
+)
+def litellm_provider_from_api_base(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") != "litellm" or not isinstance(backend.get("config"), dict):
+            continue
+        config = backend["config"]
+        api_base = str(config.get("api_base") or "")
+        if "api.openai.com" in api_base:
+            ctx.fill(
+                config,
+                key="provider",
+                value="openai",
+                path=f"backends[{index}].config.provider",
+            )
+        elif "api.deepseek.com" in api_base:
+            ctx.fill(
+                config,
+                key="provider",
+                value="deepseek",
+                path=f"backends[{index}].config.provider",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=10,
+    name="litellm_api_base_from_provider",
+    description="Fill LiteLLM api_base from known providers.",
+)
+def litellm_api_base_from_provider(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") != "litellm" or not isinstance(backend.get("config"), dict):
+            continue
+        config = backend["config"]
+        provider = str(config.get("provider") or "").lower()
+        api_base = _LITELLM_API_BASES.get(provider)
+        if api_base:
+            ctx.fill(
+                config,
+                key="api_base",
+                value=api_base,
+                path=f"backends[{index}].config.api_base",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=30,
+    name="litellm_streaming_default",
+    description="Fill LiteLLM streaming default.",
+)
+def litellm_streaming_default(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") == "litellm" and isinstance(backend.get("config"), dict):
+            ctx.fill(
+                backend["config"],
+                key="streaming",
+                value=False,
+                path=f"backends[{index}].config.streaming",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="backend",
+    priority=30,
+    name="litellm_max_retries_default",
+    description="Fill LiteLLM max_retries default.",
+)
+def litellm_max_retries_default(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, backend in _iter_indexed_dicts(payload.get("backends")):
+        if backend.get("type") == "litellm" and isinstance(backend.get("config"), dict):
+            ctx.fill(
+                backend["config"],
+                key="max_retries",
+                value=6,
+                path=f"backends[{index}].config.max_retries",
+            )
+
+
+@smart_default(
+    scene="static",
+    phase="role_adapter",
+    priority=20,
+    name="auto_dut_role_adapters",
+    description="Generate DUT role adapters from backends when adapters are omitted.",
+)
+def auto_dut_role_adapters(payload: dict[str, Any], ctx: RuleContext) -> None:
+    existing = payload.get("role_adapters")
+    if existing:
+        return
+
+    adapters = [
+        {
+            "adapter_id": f"dut_{backend_id}",
+            "role_type": "dut_model",
+            "backend_id": backend_id,
+            "capabilities": ["chat_completion"],
+        }
+        for backend_id in _backend_ids(payload)
+    ]
+    if adapters:
+        payload["role_adapters"] = adapters
+        ctx.traces.append(
+            DefaultTrace(rule=ctx.current_rule, action="replace_subtree", path="role_adapters")
+        )
+
+
+@smart_default(
+    scene="static",
+    phase="custom_steps",
+    priority=20,
+    name="auto_custom_steps",
+    description="Generate inference/auto_eval custom steps for pure DUT configs.",
+)
+def auto_custom_steps(payload: dict[str, Any], ctx: RuleContext) -> None:
+    custom = payload.get("custom")
+    if custom is not None and not isinstance(custom, dict):
+        ctx.fail("custom must be a mapping", path="custom")
+    custom = custom or {}
+    if "steps" in custom:
+        return
+
+    adapters = list(_iter_dicts(payload.get("role_adapters")))
+    if not adapters or any(adapter.get("role_type") != "dut_model" for adapter in adapters):
+        return
+
+    custom["steps"] = [{"step": "inference"}, {"step": "auto_eval"}]
+    payload["custom"] = custom
+    ctx.traces.append(DefaultTrace(rule=ctx.current_rule, action="fill", path="custom.steps"))
+
+
+@smart_default(
+    scene="static",
+    phase="task",
+    priority=5,
+    name="single_task_fallback",
+    description="Generate a single task for one dataset and one DUT adapter.",
+)
+def single_task_fallback(payload: dict[str, Any], ctx: RuleContext) -> None:
+    if "tasks" in payload or "task" in payload:
+        return
+
+    datasets = list(_iter_dicts(payload.get("datasets")))
+    adapters = [
+        item
+        for item in _iter_dicts(payload.get("role_adapters"))
+        if item.get("role_type") == "dut_model"
+    ]
+    if len(datasets) == 1 and len(adapters) == 1:
+        payload["tasks"] = [
+            {"task_id": _metadata_name(payload), "dataset_id": datasets[0].get("dataset_id")}
+        ]
+        ctx.traces.append(
+            DefaultTrace(rule=ctx.current_rule, action="replace_subtree", path="tasks")
+        )
+
+
+@smart_default(
+    scene="static",
+    phase="task",
+    priority=6,
+    name="task_singular_alias",
+    description="Lower top-level task to tasks list.",
+)
+def task_singular_alias(payload: dict[str, Any], ctx: RuleContext) -> None:
+    if "task" in payload and "tasks" in payload:
+        ctx.fail("task and tasks cannot both be declared")
+    if "task" not in payload:
+        return
+
+    task = payload.pop("task")
+    if not isinstance(task, dict):
+        ctx.fail("task must be a mapping", path="task")
+    payload["tasks"] = [task]
+    ctx.traces.append(DefaultTrace(rule=ctx.current_rule, action="replace_subtree", path="tasks"))
+
+
+@smart_default(
+    scene="static",
+    phase="task",
+    priority=10,
+    name="task_implicit_ids",
+    description="Fill task_id and dataset_id for single-task static configs.",
+)
+def task_implicit_ids(payload: dict[str, Any], ctx: RuleContext) -> None:
+    datasets = list(_iter_dicts(payload.get("datasets")))
+    for index, task in _iter_indexed_dicts(payload.get("tasks")):
+        ctx.fill(task, key="task_id", value=_metadata_name(payload), path=f"tasks[{index}].task_id")
+        if "dataset_id" in task:
+            continue
+        if len(datasets) != 1:
+            ctx.fail(
+                "task omitted dataset_id but config does not have exactly one dataset",
+                path=f"tasks[{index}]",
+            )
+        task["dataset_id"] = datasets[0].get("dataset_id")
+        ctx.traces.append(
+            DefaultTrace(rule=ctx.current_rule, action="fill", path=f"tasks[{index}].dataset_id")
+        )
+
+
+@smart_default(
+    scene="static",
+    phase="task",
+    priority=15,
+    name="task_backend_from_single_dut",
+    description="Fill task.backend when there is exactly one DUT adapter.",
+)
+def task_backend_from_single_dut(payload: dict[str, Any], ctx: RuleContext) -> None:
+    if getattr(ctx.cli_intent, "backend_id", None):
+        return
+
+    dut_adapters = [
+        item
+        for item in _iter_dicts(payload.get("role_adapters"))
+        if item.get("role_type") == "dut_model"
+    ]
+    for index, task in _iter_indexed_dicts(payload.get("tasks")):
+        if task.get("backend"):
+            continue
+        if len(dut_adapters) != 1:
+            ctx.fail(
+                "task omitted backend but config does not have exactly one DUT adapter",
+                path=f"tasks[{index}]",
+            )
+        backend_id = dut_adapters[0].get("backend_id")
+        if not backend_id:
+            ctx.fail("single DUT adapter is missing backend_id", path=f"tasks[{index}]")
+        task["backend"] = backend_id
+        ctx.traces.append(
+            DefaultTrace(rule=ctx.current_rule, action="fill", path=f"tasks[{index}].backend")
+        )
+
+
+def _find_unique_dut_adapter(
+    payload: dict[str, Any], backend_id: str, ctx: RuleContext, *, path: str
+) -> str:
+    matches = [
+        adapter.get("adapter_id")
+        for adapter in _iter_dicts(payload.get("role_adapters"))
+        if adapter.get("role_type") == "dut_model" and adapter.get("backend_id") == backend_id
+    ]
+    adapter_ids = [str(item) for item in matches if item]
+    if len(adapter_ids) != 1:
+        ctx.fail(f"cannot find unique DUT adapter for backend '{backend_id}'", path=path)
+    return adapter_ids[0]
+
+
+@smart_default(
+    scene="static",
+    phase="task",
+    priority=20,
+    name="task_backend_expand",
+    description="Lower task.backend or CLI backend_id to inference adapter binding.",
+)
+def task_backend_expand(payload: dict[str, Any], ctx: RuleContext) -> None:
+    custom = payload.get("custom") if isinstance(payload.get("custom"), dict) else {}
+    custom_steps = custom.get("steps") if isinstance(custom, dict) else []
+
+    for task_index, task in _iter_indexed_dicts(payload.get("tasks")):
+        cli_backend = getattr(ctx.cli_intent, "backend_id", None)
+        if cli_backend:
+            target_backend = cli_backend
+            target_backend_path = "cli.backend_id"
+        else:
+            target_backend = task.get("backend")
+            target_backend_path = f"tasks[{task_index}].backend"
+        if not target_backend:
+            continue
+
+        target_adapter = _find_unique_dut_adapter(
+            payload, str(target_backend), ctx, path=target_backend_path
+        )
+        if not task.get("steps"):
+            if not custom_steps:
+                ctx.fail(
+                    "task specified backend but no custom.steps or task.steps are available",
+                    path=f"tasks[{task_index}]",
+            )
+            task["steps"] = deepcopy(custom_steps)
+        inference_steps = [
+            step
+            for step in task.get("steps") or []
+            if isinstance(step, dict) and step.get("step") == "inference"
+        ]
+        if len(inference_steps) != 1:
+            ctx.fail(
+                "task must have exactly one inference step to bind backend",
+                path=f"tasks[{task_index}].steps",
+            )
+
+        inference = inference_steps[0]
+        existing = inference.get("adapter_id")
+        if existing and existing != target_adapter:
+            ctx.fail(
+                "inference step is already bound to a different adapter",
+                path=f"tasks[{task_index}].steps",
+            )
+        inference["adapter_id"] = target_adapter
+        task.pop("backend", None)
+
+
+@smart_default(
+    scene="static",
+    phase="task",
+    priority=30,
+    name="task_reporting_default",
+    description="Fill standard console/file reporting sinks.",
+)
+def task_reporting_default(payload: dict[str, Any], ctx: RuleContext) -> None:
+    for index, task in _iter_indexed_dicts(payload.get("tasks")):
+        ctx.fill(
+            task,
+            key="reporting",
+            value={"sinks": [{"type": "console"}, {"type": "file"}]},
+            path=f"tasks[{index}].reporting",
+        )

--- a/src/gage_eval/config/smart_defaults/types.py
+++ b/src/gage_eval/config/smart_defaults/types.py
@@ -1,0 +1,92 @@
+"""Core types for smart-default rule execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Literal, NoReturn, TypeAlias
+
+SceneName: TypeAlias = Literal["static", "agent", "game", "legacy"]
+
+
+class SmartDefaultsError(ValueError):
+    """Raised when smart defaults cannot materialize a config."""
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultTrace:
+    """A single smart-default mutation trace."""
+
+    rule: str
+    action: str
+    path: str
+
+
+@dataclass(slots=True)
+class RuleContext:
+    """Caller-owned execution context shared by smart-default rules."""
+
+    source_path: Path | None
+    cli_intent: Any
+    scene: str
+    traces: list[DefaultTrace] = field(default_factory=list)
+    current_rule: str = "<unknown>"
+
+    def fill(self, target: dict[str, Any], *, key: str, value: Any, path: str) -> None:
+        """Set a key only when it is absent and record the mutation."""
+
+        if key in target:
+            return
+        target[key] = value
+        self.traces.append(DefaultTrace(rule=self.current_rule, action="fill", path=path))
+
+    def migrate(
+        self,
+        source: dict[str, Any],
+        *,
+        source_key: str,
+        target: dict[str, Any],
+        target_key: str,
+        path: str,
+    ) -> None:
+        """Move a value when present while preserving an explicit target value."""
+
+        if source_key not in source:
+            return
+        if target_key not in target:
+            target[target_key] = source[source_key]
+        source.pop(source_key, None)
+        self.traces.append(DefaultTrace(rule=self.current_rule, action="migrate", path=path))
+
+    def replace_subtree(self, target: dict[str, Any], *, key: str, value: Any, path: str) -> None:
+        """Replace a nested mapping value and record the mutation."""
+
+        target[key] = value
+        self.traces.append(DefaultTrace(rule=self.current_rule, action="replace_subtree", path=path))
+
+    def fail(self, message: str, *, path: str | None = None) -> NoReturn:
+        """Abort the current rule with a smart-defaults error."""
+
+        location = f" at {path}" if path else ""
+        raise SmartDefaultsError(f"{message}{location}")
+
+
+@dataclass(frozen=True, slots=True)
+class SmartDefaultRule:
+    """A registered rule that can mutate a smart-default payload."""
+
+    scene: SceneName
+    phase: str
+    priority: int
+    name: str
+    description: str
+    apply: Callable[[dict[str, Any], RuleContext], None]
+
+
+@dataclass(frozen=True, slots=True)
+class SmartDefaultsProfile:
+    """Scene-specific execution profile for smart-default rules."""
+
+    scene: SceneName
+    phases: tuple[str, ...]
+    rules: tuple[SmartDefaultRule, ...] = ()

--- a/src/gage_eval/evaluation/sample_envelope.py
+++ b/src/gage_eval/evaluation/sample_envelope.py
@@ -221,12 +221,8 @@ def _build_arena_footer(
         footer_source.get("total_steps", footer_source.get("move_count")),
         _coerce_int(result.get("move_count"), len(trace_steps)),
     )
-    if (
-        not explicit_total_steps
-        and trace_steps
-        and len(trace_steps) != total_steps
-    ):
-        total_steps = len(trace_steps)
+    if not explicit_total_steps and trace_steps:
+        total_steps = max(total_steps, len(trace_steps))
     winner = (
         _coerce_optional_str(footer_source.get("winner_player_id"))
         or _coerce_optional_str(footer_source.get("winner"))

--- a/src/gage_eval/registry/manifests/arena.json
+++ b/src/gage_eval/registry/manifests/arena.json
@@ -30,6 +30,15 @@
     },
     {
       "kind": "arena_impls",
+      "name": "gymnasium_atari_space_invaders_v1",
+      "module": "gage_eval.game_kits.gymnasium_atari.envs.space_invaders",
+      "load_phase": "prepare_only",
+      "declared_in": "src/gage_eval/game_kits/gymnasium_atari/envs/space_invaders.py",
+      "aliases": [],
+      "optional": false
+    },
+    {
+      "kind": "arena_impls",
       "name": "mahjong_rlcard_v1",
       "module": "gage_eval.game_kits.phase_card_game.mahjong.environment",
       "load_phase": "prepare_only",
@@ -106,6 +115,15 @@
       "module": "gage_eval.game_kits.board_game.gomoku.kit",
       "load_phase": "prepare_only",
       "declared_in": "src/gage_eval/game_kits/board_game/gomoku/kit.py",
+      "aliases": [],
+      "optional": false
+    },
+    {
+      "kind": "game_kits",
+      "name": "gymnasium_atari",
+      "module": "gage_eval.game_kits.gymnasium_atari.kit",
+      "load_phase": "prepare_only",
+      "declared_in": "src/gage_eval/game_kits/gymnasium_atari/kit.py",
       "aliases": [],
       "optional": false
     },

--- a/src/gage_eval/role/arena/output/writer.py
+++ b/src/gage_eval/role/arena/output/writer.py
@@ -126,8 +126,8 @@ def _build_footer_contract(
         }
 
     total_steps = _coerce_int(_read_value(result, "move_count"), len(arena_trace))
-    if arena_trace and len(arena_trace) != total_steps:
-        total_steps = len(arena_trace)
+    if arena_trace:
+        total_steps = max(total_steps, len(arena_trace))
     footer: dict[str, object] = {
         "winner_player_id": _coerce_optional_str(_read_value(result, "winner")),
         "termination_reason": str(

--- a/src/gage_eval/tools/config_checker.py
+++ b/src/gage_eval/tools/config_checker.py
@@ -9,6 +9,7 @@ from typing import Sequence
 
 import yaml
 
+from gage_eval.config.loader import load_pipeline_config_payload, materialize_pipeline_config_payload
 from gage_eval.config.pipeline_config import PipelineConfig
 from gage_eval.evaluation.task_plan import build_task_plan_specs
 from gage_eval.tools.distill import calculate_definition_digest
@@ -48,6 +49,7 @@ def _validate_builtin_template(payload: dict, *, materialize_runtime: bool = Fal
 
     pipeline_payload = {"api_version": "gage/v1alpha1", "kind": "PipelineConfig"}
     pipeline_payload.update(definition)
+    pipeline_payload = materialize_pipeline_config_payload(pipeline_payload, source_path=None)
     config = PipelineConfig.from_dict(pipeline_payload)
     build_task_plan_specs(config)
 
@@ -71,6 +73,7 @@ def validate_config(path: Path, *, materialize_runtime: bool = False) -> None:
         print(f"[gage-eval] ✓ (BuiltinTemplate) {path}")
         return
 
+    payload = load_pipeline_config_payload(path)
     config = PipelineConfig.from_dict(payload)
     build_task_plan_specs(config)
     if materialize_runtime:

--- a/src/gage_eval/tools/distill.py
+++ b/src/gage_eval/tools/distill.py
@@ -16,6 +16,7 @@ from typing import Mapping, Sequence
 
 import yaml
 
+from gage_eval.config.loader import RunConfigCompiler, load_pipeline_config_payload
 from gage_eval.config.schema import SchemaValidationError, normalize_pipeline_payload
 
 
@@ -32,18 +33,13 @@ class DistillTaskAnalysis:
     is_monolithic: bool
 
 
-def load_pipeline_payload(path: Path) -> dict:
-    """Load a YAML config into a dictionary.
+def load_pipeline_payload(path: Path, *, run_config_compiler: RunConfigCompiler | None = None) -> dict:
+    """Load and materialize a PipelineConfig payload for distillation."""
 
-    This helper keeps the loader trivial; schema validation is deferred to
-    :func:`analyze_tasks_for_distill`.
-    """
-
-    with path.expanduser().open("r", encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
-    if not isinstance(data, dict):
-        raise DistillError(f"Config '{path}' must be a mapping at the top level")
-    return data
+    try:
+        return load_pipeline_config_payload(path, run_config_compiler=run_config_compiler)
+    except Exception as exc:
+        raise DistillError(str(exc)) from exc
 
 
 def analyze_tasks_for_distill(payload: dict, *, force_merge: bool = False) -> DistillTaskAnalysis:

--- a/tests/data/samples/agent_noop.jsonl
+++ b/tests/data/samples/agent_noop.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":"gage.v1","id":"agent_noop_0001","task_type":"agent","messages":[{"role":"user","content":[{"type":"text","text":"Return a no-op response."}]}]}

--- a/tests/data/samples/game_noop.jsonl
+++ b/tests/data/samples/game_noop.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":"gage.v1","id":"game_noop_0001","task_type":"game","messages":[{"role":"user","content":[{"type":"text","text":"Take a no-op game action."}]}]}

--- a/tests/fixtures/static_eval/agent_noop.yaml
+++ b/tests/fixtures/static_eval/agent_noop.yaml
@@ -1,0 +1,43 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: agent
+metadata:
+  name: agent_noop
+datasets:
+  - dataset_id: agent_ds
+    loader: jsonl
+    params:
+      path: tests/data/samples/agent_noop.jsonl
+backends:
+  - backend_id: main_backend
+    type: litellm
+    config:
+      provider: openai
+      model: gpt-4.1
+  - backend_id: other_backend
+    type: litellm
+    config:
+      provider: openai
+      model: gpt-4.1-mini
+role_adapters:
+  - adapter_id: agent_actor
+    role_type: dut_model
+    backend_id: main_backend
+    capabilities:
+      - chat_completion
+custom:
+  steps:
+    - step: inference
+      adapter_id: agent_actor
+    - step: auto_eval
+tasks:
+  - task_id: agent_task
+    dataset_id: agent_ds
+    backend: other_backend
+    steps:
+      - step: inference
+        adapter_id: agent_actor
+      - step: auto_eval
+    reporting:
+      sinks:
+        - type: console

--- a/tests/fixtures/static_eval/aime24_short.expanded.yaml
+++ b/tests/fixtures/static_eval/aime24_short.expanded.yaml
@@ -1,0 +1,53 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+metadata:
+  name: aime24
+datasets:
+- dataset_id: aime24_ds
+  params:
+    preprocess: aime2024_preprocessor
+    preprocess_kwargs: {}
+  hub: huggingface
+  loader: hf_hub
+  hub_params:
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+backends:
+- backend_id: openai
+  type: litellm
+  config:
+    provider: openai
+    model: gpt-4.1
+    api_base: https://api.openai.com/v1
+    max_retries: 6
+    streaming: false
+metrics:
+- aime2024_accuracy
+role_adapters:
+- adapter_id: dut_openai
+  role_type: dut_model
+  backend_id: openai
+  capabilities:
+  - chat_completion
+custom:
+  steps:
+  - step: inference
+  - step: auto_eval
+tasks:
+- max_samples: 30
+  task_id: aime24
+  dataset_id: aime24_ds
+  steps:
+  - step: inference
+    adapter_id: dut_openai
+  - step: auto_eval
+  reporting:
+    sinks:
+    - type: console
+    - type: file
+models: []
+agent_backends: []
+sandbox_profiles: []
+mcp_clients: []
+prompts: []
+summary_generators: []

--- a/tests/fixtures/static_eval/aime24_short.yaml
+++ b/tests/fixtures/static_eval/aime24_short.yaml
@@ -1,0 +1,21 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+metadata:
+  name: aime24
+datasets:
+  - dataset_id: aime24_ds
+    hub_id: Maxwell-Jia/AIME_2024
+    split: train
+    params:
+      preprocess: aime2024_preprocessor
+backends:
+  - backend_id: openai
+    type: litellm
+    config:
+      provider: openai
+      model: gpt-4.1
+metrics:
+  - aime2024_accuracy
+task:
+  max_samples: 30

--- a/tests/fixtures/static_eval/game_noop.yaml
+++ b/tests/fixtures/static_eval/game_noop.yaml
@@ -1,0 +1,43 @@
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: game
+metadata:
+  name: game_noop
+datasets:
+  - dataset_id: game_ds
+    loader: jsonl
+    params:
+      path: tests/data/samples/game_noop.jsonl
+backends:
+  - backend_id: main_backend
+    type: litellm
+    config:
+      provider: openai
+      model: gpt-4.1
+  - backend_id: other_backend
+    type: litellm
+    config:
+      provider: openai
+      model: gpt-4.1-mini
+role_adapters:
+  - adapter_id: game_player
+    role_type: dut_model
+    backend_id: main_backend
+    capabilities:
+      - chat_completion
+custom:
+  steps:
+    - step: inference
+      adapter_id: game_player
+    - step: auto_eval
+tasks:
+  - task_id: game_task
+    dataset_id: game_ds
+    backend: other_backend
+    steps:
+      - step: inference
+        adapter_id: game_player
+      - step: auto_eval
+    reporting:
+      sinks:
+        - type: console

--- a/tests/game_arena/core/test_realtime_inline_media.py
+++ b/tests/game_arena/core/test_realtime_inline_media.py
@@ -83,6 +83,7 @@ def test_game_session_realtime_live_snapshots_throttle_inline_frame_images_for_q
                 input_transport="realtime_ws",
                 frame_output_hz=20,
                 artifact_sampling_mode="async_decimated_live",
+                snapshot_persist_stride=1,
                 fallback_move="noop",
             ),
         ),

--- a/tests/game_arena/game_kits/test_runtime_binding_resolver.py
+++ b/tests/game_arena/game_kits/test_runtime_binding_resolver.py
@@ -124,8 +124,8 @@ def test_runtime_binding_resolver_parses_scheduler_owned_queued_command_v1_polic
                 {
                     "input_semantics": "continuous_state",
                     "stateful_actions": True,
-                    "tick_interval_ms": 16,
-                    "timeout_ms": 16,
+                    "tick_interval_ms": 18,
+                    "timeout_ms": 18,
                     "timeout_fallback_move": "noop",
                 },
             ),
@@ -144,8 +144,8 @@ def test_runtime_binding_resolver_parses_scheduler_owned_queued_command_v1_polic
                 {
                     "input_semantics": "continuous_state",
                     "stateful_actions": True,
-                    "tick_interval_ms": 16,
-                    "timeout_ms": 16,
+                    "tick_interval_ms": 18,
+                    "timeout_ms": 18,
                     "timeout_fallback_move": "noop",
                 },
             ),
@@ -206,7 +206,7 @@ def test_runtime_binding_resolver_preserves_human_driver_params_from_config(
         (
             "config/custom/retro_mario/retro_mario_human_visual_gamekit.yaml",
             "continuous_state",
-            16,
+            18,
             True,
             True,
             True,

--- a/tests/integration/runtime/test_human_visual_gamekit_configs.py
+++ b/tests/integration/runtime/test_human_visual_gamekit_configs.py
@@ -329,11 +329,12 @@ def test_retro_mario_human_visual_config_routes_human_input_to_player_0() -> Non
             "activation_scope": "pure_human_only",
             "input_model": "continuous_state",
             "input_transport": "realtime_ws",
-            "tick_interval_ms": 16,
+            "tick_interval_ms": 18,
             "frame_output_hz": 60,
             "artifact_sampling_mode": "async_decimated_live",
             "snapshot_persist_stride": 3,
             "fallback_move": "noop",
+            "command_stale_after_ms": 200,
         },
     }
     assert visualizer["enabled"] is True
@@ -349,8 +350,8 @@ def test_retro_mario_human_visual_config_routes_human_input_to_player_0() -> Non
             "driver_params": {
                 "input_semantics": "continuous_state",
                 "stateful_actions": True,
-                "tick_interval_ms": 16,
-                "timeout_ms": 16,
+                "tick_interval_ms": 18,
+                "timeout_ms": 18,
                 "timeout_fallback_move": "noop",
             },
         }

--- a/tests/integration/scenarios/cli/test_static_expanded_config_cli.py
+++ b/tests/integration/scenarios/cli/test_static_expanded_config_cli.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+import run as gage_run
+
+
+@pytest.mark.io
+def test_show_expanded_config_prints_yaml_without_runtime_preflight(monkeypatch, capsys) -> None:
+    cfg = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+    monkeypatch.setattr(
+        gage_run,
+        "_ensure_spawn_start_method",
+        lambda: (_ for _ in ()).throw(AssertionError("runtime preflight should not run")),
+    )
+    monkeypatch.setattr(sys, "argv", ["run.py", "--config", str(cfg), "--show-expanded-config"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    expanded = yaml.safe_load(captured.out)
+    assert excinfo.value.code == 0
+    assert "scene" not in expanded
+    assert expanded["role_adapters"][0]["adapter_id"] == "dut_openai"
+    assert expanded["tasks"][0]["task_id"] == "aime24"
+    assert expanded["tasks"][0]["steps"][0] == {"step": "inference", "adapter_id": "dut_openai"}
+    for key in (
+        "models",
+        "agent_backends",
+        "sandbox_profiles",
+        "mcp_clients",
+        "prompts",
+        "summary_generators",
+    ):
+        assert key not in expanded
+
+
+@pytest.mark.io
+def test_show_expanded_config_preserves_non_empty_optional_sections(monkeypatch, capsys, tmp_path) -> None:
+    cfg = tmp_path / "with_prompt.yaml"
+    cfg.write_text(
+        """
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+metadata: { name: with_prompt }
+datasets:
+  - dataset_id: ds
+    loader: jsonl
+    params: { path: dummy.jsonl }
+backends:
+  - backend_id: openai
+    type: litellm
+    config: { provider: openai, model: gpt-4.1 }
+prompts:
+  - prompt_id: p1
+    renderer: jinja
+    template: "Answer directly."
+role_adapters:
+  - adapter_id: dut_openai
+    role_type: dut_model
+    backend_id: openai
+    prompt_id: p1
+metrics: [exact_match]
+task: {}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "argv", ["run.py", "--config", str(cfg), "--show-expanded-config"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    expanded = yaml.safe_load(captured.out)
+    assert excinfo.value.code == 0
+    assert expanded["prompts"] == [
+        {"prompt_id": "p1", "renderer": "jinja", "template": "Answer directly."}
+    ]
+
+
+@pytest.mark.io
+def test_show_expanded_config_honors_backend_id(monkeypatch, capsys, tmp_path) -> None:
+    cfg = tmp_path / "dual.yaml"
+    cfg.write_text(
+        """
+api_version: gage/v1alpha1
+kind: PipelineConfig
+scene: static
+metadata: { name: dual }
+datasets:
+  - dataset_id: ds
+    loader: jsonl
+    params: { path: dummy.jsonl }
+backends:
+  - backend_id: openai
+    type: litellm
+    config: { provider: openai, model: gpt-4.1 }
+  - backend_id: vllm_qwen
+    type: vllm
+    config: { model_path: /models/qwen }
+metrics: [exact_match]
+task:
+  backend: openai
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run.py", "--config", str(cfg), "--show-expanded-config", "--backend-id", "vllm_qwen"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    expanded = yaml.safe_load(captured.out)
+    assert excinfo.value.code == 0
+    assert expanded["tasks"][0]["steps"][0] == {"step": "inference", "adapter_id": "dut_vllm_qwen"}
+
+
+@pytest.mark.io
+def test_show_expanded_config_compiles_runconfig_before_materializing(monkeypatch, capsys, tmp_path) -> None:
+    cfg = tmp_path / "run_config.yaml"
+    cfg.write_text(
+        """
+api_version: gage/v1alpha1
+kind: RunConfig
+metadata: { name: static_run }
+""",
+        encoding="utf-8",
+    )
+    compiled = {
+        "api_version": "gage/v1alpha1",
+        "kind": "PipelineConfig",
+        "scene": "static",
+        "metadata": {"name": "compiled_static"},
+        "datasets": [{"dataset_id": "ds", "loader": "jsonl", "params": {"path": "dummy.jsonl"}}],
+        "backends": [
+            {
+                "backend_id": "openai",
+                "type": "litellm",
+                "config": {"provider": "openai", "model": "gpt-4.1"},
+            }
+        ],
+        "metrics": ["exact_match"],
+        "task": {},
+    }
+
+    monkeypatch.setattr(gage_run, "_compile_run_config", lambda payload: (compiled, tmp_path / "template.yaml"))
+    monkeypatch.setattr(sys, "argv", ["run.py", "--config", str(cfg), "--show-expanded-config"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    expanded = yaml.safe_load(captured.out)
+    assert excinfo.value.code == 0
+    assert expanded["tasks"][0]["task_id"] == "compiled_static"
+    assert expanded["tasks"][0]["steps"][0] == {"step": "inference", "adapter_id": "dut_openai"}
+
+
+@pytest.mark.io
+def test_show_expanded_config_reports_runconfig_compile_error(monkeypatch, capsys, tmp_path) -> None:
+    cfg = tmp_path / "run_config.yaml"
+    cfg.write_text(
+        "api_version: gage/v1alpha1\nkind: RunConfig\nmetadata: { name: static_run }\n",
+        encoding="utf-8",
+    )
+
+    def fail_compile(payload):
+        raise ValueError("compile failed")
+
+    monkeypatch.setattr(gage_run, "_compile_run_config", fail_compile)
+    monkeypatch.setattr(sys, "argv", ["run.py", "--config", str(cfg), "--show-expanded-config"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 1
+    assert "compile failed" in captured.err
+
+
+@pytest.mark.io
+def test_no_smart_defaults_prints_pre_smart_payload_for_short_static_config(monkeypatch, capsys) -> None:
+    cfg = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run.py", "--config", str(cfg), "--show-expanded-config", "--no-smart-defaults"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    expanded = yaml.safe_load(captured.out)
+    assert excinfo.value.code == 0
+    assert expanded["scene"] == "static"
+    assert expanded["datasets"][0]["hub_id"] == "Maxwell-Jia/AIME_2024"
+    assert "task" in expanded
+    assert "role_adapters" not in expanded
+    assert "custom" not in expanded
+
+
+@pytest.mark.io
+def test_max_samples_zero_uses_materialized_static_payload(monkeypatch, capsys) -> None:
+    cfg = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+    seen: dict[str, list[str]] = {}
+
+    monkeypatch.delenv("GAGE_EVAL_THREADS", raising=False)
+    monkeypatch.delenv("GAGE_EVAL_MAX_SAMPLES", raising=False)
+    monkeypatch.setattr(gage_run, "_ensure_spawn_start_method", lambda: None)
+    monkeypatch.setattr(gage_run, "_ensure_default_concurrency", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gage_run, "_detect_hardware_profile", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gage_run, "_apply_hardware_profile_env", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gage_run, "_preflight_checks", lambda: None)
+    monkeypatch.setattr(gage_run, "_install_signal_handlers", lambda: None)
+    monkeypatch.setattr(gage_run, "build_default_registry", lambda: "registry")
+
+    def fake_validate(config, **kwargs):
+        seen["tasks"] = [task.task_id for task in config.tasks]
+        seen["adapters"] = [adapter.adapter_id for adapter in config.role_adapters]
+        return []
+
+    monkeypatch.setattr(gage_run, "_validate_config_wiring", fake_validate)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run.py", "--config", str(cfg), "--max-samples", "0", "--gpus", "0", "--cpus", "1"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert seen == {"tasks": ["aime24"], "adapters": ["dut_openai"]}
+    assert "config wiring validated" in captured.out
+
+
+@pytest.mark.io
+def test_negative_max_samples_exits_before_config_materialization(monkeypatch, capsys) -> None:
+    cfg = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+
+    monkeypatch.setattr(gage_run, "_ensure_spawn_start_method", lambda: None)
+    monkeypatch.setattr(gage_run, "_detect_hardware_profile", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gage_run, "_ensure_default_concurrency", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gage_run, "_apply_hardware_profile_env", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gage_run, "_preflight_checks", lambda: None)
+    monkeypatch.setattr(gage_run, "_install_signal_handlers", lambda: None)
+    monkeypatch.setattr(
+        gage_run,
+        "load_pipeline_config_payload",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("config should not be materialized")),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["run.py", "--config", str(cfg), "--max-samples", "-1", "--gpus", "0", "--cpus", "1"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2
+    assert "--max-samples must be >= 0" in captured.err

--- a/tests/integration/scenarios/distill/test_static_loader_distill.py
+++ b/tests/integration/scenarios/distill/test_static_loader_distill.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from gage_eval.config.loader import load_pipeline_config_payload
+from gage_eval.tools.distill import analyze_tasks_for_distill
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+
+@pytest.mark.io
+def test_distill_analysis_accepts_expanded_short_static_config() -> None:
+    path = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+    payload = load_pipeline_config_payload(path)
+
+    analysis = analyze_tasks_for_distill(payload)
+
+    assert analysis.mode == "ATOMIC"
+    assert analysis.task_ids == ("aime24",)
+
+
+@pytest.mark.io
+def test_run_py_distill_uses_loader_for_short_static_config(monkeypatch, tmp_path, capsys) -> None:
+    import run as gage_run
+
+    path = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+    output_root = tmp_path / "templates"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run.py",
+            "--config",
+            str(path),
+            "--distill",
+            "--builtin-name",
+            "static_suite",
+            "--distill-output",
+            str(output_root),
+        ],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert "template written" in captured.out
+    assert (output_root / "static_suite" / "v1.yaml").exists()
+
+
+@pytest.mark.io
+def test_run_py_distill_compiles_runconfig_through_loader(monkeypatch, tmp_path, capsys) -> None:
+    import run as gage_run
+
+    run_config = tmp_path / "run_config.yaml"
+    run_config.write_text("api_version: gage/v1alpha1\nkind: RunConfig\nmetadata: { name: rc }\n", encoding="utf-8")
+    compiled = {
+        "api_version": "gage/v1alpha1",
+        "kind": "PipelineConfig",
+        "scene": "static",
+        "metadata": {"name": "compiled_static"},
+        "datasets": [{"dataset_id": "ds", "loader": "jsonl", "params": {"path": "dummy.jsonl"}}],
+        "backends": [{"backend_id": "openai", "type": "litellm", "config": {"provider": "openai", "model": "gpt-4.1"}}],
+        "metrics": ["exact_match"],
+        "task": {},
+    }
+    output_root = tmp_path / "templates"
+    monkeypatch.setattr(gage_run, "_compile_run_config", lambda payload: (compiled, tmp_path / "template.yaml"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run.py",
+            "--config",
+            str(run_config),
+            "--distill",
+            "--builtin-name",
+            "runconfig_suite",
+            "--distill-output",
+            str(output_root),
+        ],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        gage_run.main()
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 0
+    assert "template written" in captured.out
+    assert (output_root / "runconfig_suite" / "v1.yaml").exists()

--- a/tests/unit/config/test_loader_cli_overrides.py
+++ b/tests/unit/config/test_loader_cli_overrides.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import pytest
+
+from gage_eval.config.loader import materialize_pipeline_config_payload
+from gage_eval.config.schema import SchemaValidationError
+from gage_eval.config.loader_cli import CLIIntent, apply_cli_final_overrides, parse_metric_ids_csv
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ("", None),
+        (" exact_match, , full_metric ", ("exact_match", "full_metric")),
+    ],
+)
+def test_parse_metric_ids_csv_trims_items_and_drops_empty_values(
+    raw: str | None,
+    expected: tuple[str, ...] | None,
+) -> None:
+    assert parse_metric_ids_csv(raw) == expected
+
+
+@pytest.mark.fast
+def test_metric_ids_filter_supports_all_metric_entry_forms() -> None:
+    payload = {
+        "metrics": [
+            "exact_match",
+            "fn_metric(case_sensitive=false)",
+            {"kv_metric": {"case_sensitive": True}},
+            {"metric_id": "full_metric", "implementation": "custom_impl"},
+        ],
+        "tasks": [{"task_id": "t1", "dataset_id": "ds"}],
+    }
+
+    apply_cli_final_overrides(payload, CLIIntent(metric_ids=("exact_match", "kv_metric", "full_metric")))
+
+    assert payload["metrics"] == [
+        "exact_match",
+        {"kv_metric": {"case_sensitive": True}},
+        {"metric_id": "full_metric", "implementation": "custom_impl"},
+    ]
+
+
+@pytest.mark.fast
+def test_max_samples_override_updates_materialized_tasks_and_dataset_limits() -> None:
+    payload = {
+        "datasets": [{"dataset_id": "ds", "params": {}, "hub_params": {}}],
+        "tasks": [{"task_id": "t1", "dataset_id": "ds"}],
+    }
+
+    apply_cli_final_overrides(payload, CLIIntent(max_samples=0))
+
+    assert payload["tasks"][0]["max_samples"] == 0
+    assert payload["datasets"][0]["params"]["limit"] == 0
+    assert payload["datasets"][0]["hub_params"]["limit"] == 0
+
+
+@pytest.mark.fast
+def test_skip_judge_removes_judge_steps_from_custom_and_tasks() -> None:
+    payload = {
+        "custom": {"steps": [{"step": "inference"}, {"step": "judge"}, {"step": "auto_eval"}]},
+        "tasks": [{"task_id": "t1", "dataset_id": "ds", "steps": [{"step": "inference"}, {"step": "judge"}]}],
+    }
+
+    apply_cli_final_overrides(payload, CLIIntent(skip_judge=True))
+
+    assert payload["custom"]["steps"] == [{"step": "inference"}, {"step": "auto_eval"}]
+    assert payload["tasks"][0]["steps"] == [{"step": "inference"}]
+
+
+@pytest.mark.fast
+def test_skip_judge_leaves_non_list_steps_unchanged() -> None:
+    payload = {
+        "custom": {"steps": "pipeline-template"},
+        "tasks": [{"task_id": "t1", "dataset_id": "ds", "steps": "task-template"}],
+    }
+
+    apply_cli_final_overrides(payload, CLIIntent(skip_judge=True))
+
+    assert payload["custom"]["steps"] == "pipeline-template"
+    assert payload["tasks"][0]["steps"] == "task-template"
+
+
+@pytest.mark.fast
+def test_materialize_applies_cli_final_overrides_after_static_smart_defaults() -> None:
+    payload = {
+        "api_version": "gage/v1alpha1",
+        "kind": "PipelineConfig",
+        "scene": "static",
+        "metadata": {"name": "aime24"},
+        "datasets": [
+            {
+                "dataset_id": "aime24_ds",
+                "hub_id": "Maxwell-Jia/AIME_2024",
+                "split": "train",
+                "params": {},
+                "hub_params": {},
+            }
+        ],
+        "backends": [
+            {
+                "backend_id": "openai",
+                "type": "litellm",
+                "config": {"provider": "openai", "model": "gpt-4.1"},
+            }
+        ],
+        "role_adapters": [
+            {"adapter_id": "dut_openai", "role_type": "dut_model", "backend_id": "openai"},
+            {"adapter_id": "judge", "role_type": "judge_model", "backend_id": "openai"},
+        ],
+        "custom": {"steps": [{"step": "inference"}, {"step": "judge"}, {"step": "auto_eval"}]},
+        "metrics": ["exact_match", "fn_metric(case_sensitive=false)"],
+        "task": {"max_samples": 30},
+    }
+
+    normalized = materialize_pipeline_config_payload(
+        payload,
+        source_path=None,
+        cli_intent=CLIIntent(max_samples=0, metric_ids=("exact_match",), skip_judge=True),
+    )
+
+    assert normalized["tasks"][0]["max_samples"] == 0
+    assert normalized["datasets"][0]["params"]["limit"] == 0
+    assert normalized["datasets"][0]["hub_params"]["limit"] == 0
+    assert normalized["metrics"] == ["exact_match"]
+    assert normalized["custom"]["steps"] == [{"step": "inference"}, {"step": "auto_eval"}]
+    assert [step["step"] for step in normalized["tasks"][0]["steps"]] == ["inference", "auto_eval"]
+
+
+@pytest.mark.fast
+def test_metric_ids_filter_preserves_malformed_entries_for_schema_validation() -> None:
+    payload = {
+        "kind": "PipelineConfig",
+        "datasets": [{"dataset_id": "ds", "loader": "jsonl"}],
+        "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+        "custom": {"steps": [{"step": "inference", "adapter_id": "dut"}]},
+        "metrics": ["keep", 123],
+    }
+
+    with pytest.raises(SchemaValidationError, match="metric entries must be dictionaries"):
+        materialize_pipeline_config_payload(
+            payload,
+            source_path=None,
+            cli_intent=CLIIntent(metric_ids=("keep",)),
+            smart_defaults=False,
+        )
+
+
+@pytest.mark.fast
+def test_metric_ids_filter_preserves_malformed_metrics_container_for_schema_validation() -> None:
+    payload = {
+        "kind": "PipelineConfig",
+        "datasets": [{"dataset_id": "ds", "loader": "jsonl"}],
+        "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+        "custom": {"steps": [{"step": "inference", "adapter_id": "dut"}]},
+        "metrics": "",
+    }
+
+    with pytest.raises(SchemaValidationError, match="'metrics' must be a list"):
+        materialize_pipeline_config_payload(
+            payload,
+            source_path=None,
+            cli_intent=CLIIntent(metric_ids=("keep",)),
+            smart_defaults=False,
+        )
+
+
+@pytest.mark.fast
+def test_runconfig_materialization_preserves_cli_intent_when_smart_defaults_disabled() -> None:
+    payload = {"kind": "RunConfig"}
+
+    def compiler(expanded: dict[str, object]) -> tuple[dict[str, object], None]:
+        assert expanded == {"kind": "RunConfig"}
+        return (
+            {
+                "kind": "PipelineConfig",
+                "scene": "static",
+                "datasets": [{"dataset_id": "ds", "loader": "jsonl", "params": {}, "hub_params": {}}],
+                "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+                "custom": {"steps": [{"step": "inference"}, {"step": "judge"}]},
+                "metrics": ["keep", "drop"],
+                "tasks": [
+                    {
+                        "task_id": "t1",
+                        "dataset_id": "ds",
+                        "steps": [{"step": "inference"}, {"step": "judge"}],
+                        "max_samples": 5,
+                    }
+                ],
+            },
+            None,
+        )
+
+    normalized = materialize_pipeline_config_payload(
+        payload,
+        source_path=None,
+        run_config_compiler=compiler,
+        cli_intent=CLIIntent(max_samples=0, metric_ids=("keep",), skip_judge=True),
+        smart_defaults=False,
+    )
+
+    assert normalized["tasks"][0]["max_samples"] == 0
+    assert normalized["datasets"][0]["params"]["limit"] == 0
+    assert normalized["datasets"][0]["hub_params"]["limit"] == 0
+    assert normalized["metrics"] == ["keep"]
+    assert normalized["custom"]["steps"] == [{"step": "inference"}]
+    assert normalized["tasks"][0]["steps"] == [{"step": "inference"}]

--- a/tests/unit/config/test_loader_payload.py
+++ b/tests/unit/config/test_loader_payload.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gage_eval.config.loader import (
+    expand_env,
+    load_pipeline_config_payload,
+    load_pre_smart_defaults_payload,
+    load_yaml_mapping,
+    materialize_pipeline_config_payload,
+)
+from gage_eval.config.loader_cli import CLIIntent
+from gage_eval.config.smart_defaults import SmartDefaultsError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "static_eval"
+
+
+def _assert_dataset_paths_exist(payload: dict[str, object]) -> None:
+    datasets = payload.get("datasets")
+    assert isinstance(datasets, list)
+    for dataset in datasets:
+        assert isinstance(dataset, dict)
+        params = dataset.get("params")
+        assert isinstance(params, dict)
+        path = params.get("path")
+        assert isinstance(path, str)
+        assert (REPO_ROOT / path).exists()
+
+
+@pytest.mark.fast
+def test_expand_env_required_placeholder_uses_env_value(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    expanded = expand_env({"api_key": "${OPENAI_API_KEY:?set OPENAI_API_KEY}"})
+
+    assert expanded == {"api_key": "sk-test"}
+
+
+@pytest.mark.fast
+def test_expand_env_required_placeholder_reports_message(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="set OPENAI_API_KEY"):
+        expand_env({"api_key": "${OPENAI_API_KEY:?set OPENAI_API_KEY}"})
+
+
+@pytest.mark.fast
+def test_expand_env_keeps_embedded_placeholder_unchanged(monkeypatch) -> None:
+    monkeypatch.setenv("API_VERSION", "v2")
+
+    expanded = expand_env({"url": "https://api.example.com/${API_VERSION:-v1}"})
+
+    assert expanded == {"url": "https://api.example.com/${API_VERSION:-v1}"}
+
+
+@pytest.mark.fast
+def test_expand_env_expands_bare_placeholder(monkeypatch) -> None:
+    monkeypatch.setenv("PLAIN_VAR", "plain-value")
+
+    expanded = expand_env({"value": "${PLAIN_VAR}"})
+
+    assert expanded == {"value": "plain-value"}
+
+
+@pytest.mark.fast
+def test_expand_env_keeps_padded_placeholder_unchanged(monkeypatch) -> None:
+    monkeypatch.setenv("X", "9")
+
+    expanded = expand_env({"value": " ${X:-1} "})
+
+    assert expanded == {"value": " ${X:-1} "}
+
+
+@pytest.mark.io
+def test_load_yaml_mapping_rejects_top_level_list(tmp_path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("- not\n- mapping\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mapping at the top level"):
+        load_yaml_mapping(config_path)
+
+
+@pytest.mark.fast
+def test_materialize_legacy_payload_keeps_original_payload_unchanged() -> None:
+    raw = {
+        "kind": "PipelineConfig",
+        "datasets": [{"dataset_id": "ds1", "loader": "jsonl", "params": {"path": "dummy.jsonl"}}],
+        "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+        "custom": {"steps": [{"step": "inference", "adapter_id": "dut"}]},
+    }
+    before = deepcopy(raw)
+
+    normalized = materialize_pipeline_config_payload(raw, source_path=None)
+
+    assert raw == before
+    assert normalized["datasets"][0]["dataset_id"] == "ds1"
+    assert "scene" not in normalized
+
+
+@pytest.mark.fast
+def test_materialize_rejects_non_string_pipeline_scene() -> None:
+    raw = {
+        "kind": "PipelineConfig",
+        "scene": 123,
+        "datasets": [{"dataset_id": "ds1", "loader": "jsonl", "params": {"path": "dummy.jsonl"}}],
+        "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+        "custom": {"steps": [{"step": "inference", "adapter_id": "dut"}]},
+    }
+
+    with pytest.raises(SmartDefaultsError, match="Unknown PipelineConfig scene '123'"):
+        materialize_pipeline_config_payload(raw, source_path=None)
+
+
+@pytest.mark.fast
+def test_materialize_runconfig_payload_calls_compiler_and_normalizes_compiled_payload(monkeypatch) -> None:
+    monkeypatch.setenv("RUN_NAME", "demo-run")
+
+    payload = {
+        "kind": "RunConfig",
+        "metadata": {"name": "${RUN_NAME:?missing RUN_NAME}"},
+    }
+    calls: list[dict[str, object]] = []
+
+    def compiler(expanded: dict[str, object]) -> tuple[dict[str, object], None]:
+        calls.append(expanded)
+        assert expanded["metadata"]["name"] == "demo-run"
+        return (
+            {
+                "kind": "PipelineConfig",
+                "datasets": [{"dataset_id": "ds1", "loader": "jsonl"}],
+                "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+                "custom": {"steps": [{"step": "inference", "adapter_id": "dut"}]},
+                "scene": "agent",
+            },
+            None,
+        )
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None, run_config_compiler=compiler)
+
+    assert len(calls) == 1
+    assert normalized["datasets"][0]["dataset_id"] == "ds1"
+    assert "scene" not in normalized
+
+
+@pytest.mark.fast
+def test_materialize_runconfig_payload_raises_value_error_before_unbounded_recursion(tmp_path) -> None:
+    payload = {"kind": "RunConfig"}
+    source_path = tmp_path / "runconfig.yaml"
+
+    def compiler(expanded: dict[str, object]) -> tuple[dict[str, object], None]:
+        assert expanded == {"kind": "RunConfig"}
+        return {"kind": "RunConfig"}, None
+
+    with pytest.raises(ValueError, match=r"RunConfig materialization exceeded .*runconfig\.yaml"):
+        materialize_pipeline_config_payload(payload, source_path=source_path, run_config_compiler=compiler)
+
+
+@pytest.mark.fast
+def test_load_pre_smart_defaults_payload_calls_compiler_and_preserves_scene(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("RUN_NAME", "demo-run")
+
+    config_path = tmp_path / "runconfig.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "kind: RunConfig",
+                "metadata:",
+                "  name: ${RUN_NAME:?missing RUN_NAME}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    calls: list[dict[str, object]] = []
+
+    def compiler(expanded: dict[str, object]) -> tuple[dict[str, object], None]:
+        calls.append(expanded)
+        assert expanded["metadata"]["name"] == "demo-run"
+        return (
+            {
+                "kind": "PipelineConfig",
+                "datasets": [{"dataset_id": "ds1", "loader": "jsonl"}],
+                "role_adapters": [{"adapter_id": "dut", "role_type": "dut_model"}],
+                "custom": {"steps": [{"step": "inference", "adapter_id": "dut"}]},
+                "scene": "static",
+            },
+            None,
+        )
+
+    compiled = load_pre_smart_defaults_payload(config_path, run_config_compiler=compiler)
+
+    assert len(calls) == 1
+    assert compiled["kind"] == "PipelineConfig"
+    assert compiled["scene"] == "static"
+
+
+@pytest.mark.fast
+def test_load_pre_smart_defaults_payload_rejects_unknown_scene(tmp_path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "kind: PipelineConfig",
+                "scene: arena",
+                "datasets:",
+                "  - dataset_id: ds1",
+                "    loader: jsonl",
+                "role_adapters:",
+                "  - adapter_id: dut",
+                "    role_type: dut_model",
+                "custom:",
+                "  steps:",
+                "    - step: inference",
+                "      adapter_id: dut",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SmartDefaultsError, match="Unknown PipelineConfig scene 'arena'"):
+        load_pre_smart_defaults_payload(config_path)
+
+
+@pytest.mark.io
+def test_static_aime_short_fixture_matches_expanded_snapshot() -> None:
+    expanded = load_pipeline_config_payload(FIXTURE_DIR / "aime24_short.yaml")
+    actual = yaml.safe_dump(expanded, sort_keys=False)
+    expected_text = (FIXTURE_DIR / "aime24_short.expanded.yaml").read_text(encoding="utf-8")
+    expected = yaml.safe_load(expected_text)
+
+    assert expanded == expected
+    assert "scene:" not in actual
+    assert "task:" not in actual
+    assert "backend:" not in actual
+    assert "role_adapters:" in actual
+    assert "custom:" in actual
+    assert "steps:" in actual
+    assert "tasks:" in actual
+    assert "reporting:" in actual
+
+
+@pytest.mark.io
+@pytest.mark.parametrize("fixture_name", ["agent_noop.yaml", "game_noop.yaml"])
+def test_agent_and_game_fixture_scenes_do_not_apply_static_defaults(fixture_name: str) -> None:
+    path = FIXTURE_DIR / fixture_name
+    raw = load_yaml_mapping(path)
+
+    _assert_dataset_paths_exist(raw)
+    normalized = load_pipeline_config_payload(path)
+
+    assert "scene" not in normalized
+    assert normalized["datasets"] == raw["datasets"]
+    assert normalized["backends"] == raw["backends"]
+    assert normalized["role_adapters"] == raw["role_adapters"]
+    assert normalized["custom"] == raw["custom"]
+    assert normalized["tasks"][0]["backend"] == raw["tasks"][0]["backend"]
+    assert normalized["tasks"][0]["steps"] == raw["tasks"][0]["steps"]
+    assert normalized["tasks"][0]["reporting"] == raw["tasks"][0]["reporting"]
+
+
+@pytest.mark.io
+@pytest.mark.parametrize("fixture_name", ["agent_noop.yaml", "game_noop.yaml"])
+def test_agent_and_game_fixture_scenes_ignore_cli_backend_id_for_static_binding(fixture_name: str) -> None:
+    path = FIXTURE_DIR / fixture_name
+    raw = load_yaml_mapping(path)
+
+    _assert_dataset_paths_exist(raw)
+    normalized = load_pipeline_config_payload(path, cli_intent=CLIIntent(backend_id="other_backend"))
+
+    assert "scene" not in normalized
+    assert normalized["datasets"] == raw["datasets"]
+    assert normalized["backends"] == raw["backends"]
+    assert normalized["role_adapters"] == raw["role_adapters"]
+    assert normalized["custom"] == raw["custom"]
+    assert normalized["tasks"][0]["backend"] == raw["tasks"][0]["backend"]
+    assert normalized["tasks"][0]["steps"] == raw["tasks"][0]["steps"]

--- a/tests/unit/config/test_smart_defaults_profiles.py
+++ b/tests/unit/config/test_smart_defaults_profiles.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+import gage_eval.config.smart_defaults.static_rules as static_smart_default_rules
+from gage_eval.config.smart_defaults import SmartDefaultsError
+from gage_eval.config.smart_defaults.profiles import select_smart_defaults_profile
+from gage_eval.config.smart_defaults import registry as smart_defaults_registry
+from gage_eval.config.smart_defaults.registry import apply_smart_defaults, registered_rules, smart_default
+from gage_eval.config.smart_defaults.types import RuleContext
+
+
+@pytest.fixture(autouse=True)
+def restore_smart_defaults_registry() -> Generator[None, None, None]:
+    original_rules = list(smart_defaults_registry._RULES)
+    try:
+        yield
+    finally:
+        smart_defaults_registry._RULES[:] = original_rules
+
+
+def _rule_context(*, current_rule: str = "test_rule") -> RuleContext:
+    ctx = RuleContext(source_path=Path("config.yaml"), cli_intent=None, scene="static")
+    ctx.current_rule = current_rule
+    return ctx
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("payload", "expected_scene"),
+    [
+        ({"kind": "PipelineConfig", "scene": "static"}, "static"),
+        ({"kind": "PipelineConfig", "scene": "agent"}, "agent"),
+        ({"kind": "PipelineConfig", "scene": "game"}, "game"),
+        ({"kind": "PipelineConfig"}, "legacy"),
+    ],
+)
+def test_select_smart_defaults_profile_by_scene(payload, expected_scene) -> None:
+    profile = select_smart_defaults_profile(payload, Path("config.yaml"))
+
+    assert profile.scene == expected_scene
+
+
+@pytest.mark.fast
+def test_select_smart_defaults_profile_rejects_unknown_scene() -> None:
+    with pytest.raises(SmartDefaultsError, match="Unknown PipelineConfig scene 'arena'"):
+        select_smart_defaults_profile({"kind": "PipelineConfig", "scene": "arena"}, Path("config.yaml"))
+
+
+@pytest.mark.fast
+def test_static_rule_registration_is_idempotent_across_module_reload() -> None:
+    before_rules = registered_rules("static")
+    before_rule_keys = tuple((rule.scene, rule.phase, rule.name) for rule in before_rules)
+
+    importlib.reload(static_smart_default_rules)
+
+    after_rules = registered_rules("static")
+    after_rule_keys = tuple((rule.scene, rule.phase, rule.name) for rule in after_rules)
+    after_rule_names = tuple(rule.name for rule in after_rules)
+
+    assert after_rule_keys == before_rule_keys
+    assert len(after_rules) == len(before_rules)
+    assert len(after_rule_names) == len(set(after_rule_names))
+
+
+@pytest.mark.fast
+def test_duplicate_rule_registration_replaces_existing_rule_metadata_and_apply_function() -> None:
+    @smart_default(
+        scene="static",
+        phase="contract",
+        priority=10,
+        name="replaceable_rule",
+        description="Original description.",
+    )
+    def original_rule(payload: dict, ctx: RuleContext) -> None:
+        payload["registered_value"] = "original"
+
+    @smart_default(
+        scene="static",
+        phase="contract",
+        priority=20,
+        name="replaceable_rule",
+        description="Replacement description.",
+    )
+    def replacement_rule(payload: dict, ctx: RuleContext) -> None:
+        payload["registered_value"] = "replacement"
+
+    matching_rules = [
+        rule
+        for rule in registered_rules("static")
+        if (rule.scene, rule.phase, rule.name) == ("static", "contract", "replaceable_rule")
+    ]
+
+    assert len(matching_rules) == 1
+    assert matching_rules[0].priority == 20
+    assert matching_rules[0].description == "Replacement description."
+    assert matching_rules[0].apply is replacement_rule
+
+    payload: dict[str, str] = {}
+    matching_rules[0].apply(payload, _rule_context())
+
+    assert payload == {"registered_value": "replacement"}
+
+
+@pytest.mark.fast
+def test_non_pipeline_config_uses_legacy_profile() -> None:
+    profile = select_smart_defaults_profile({"kind": "RunConfig", "scene": "static"}, Path("run.yaml"))
+
+    assert profile.scene == "legacy"
+    assert profile.rules == ()
+
+
+@pytest.mark.fast
+def test_rule_context_fill_preserves_explicit_values_without_trace() -> None:
+    ctx = _rule_context()
+    target = {"existing": "explicit"}
+
+    ctx.fill(target, key="existing", value="default", path="existing")
+
+    assert target == {"existing": "explicit"}
+    assert ctx.traces == []
+
+
+@pytest.mark.fast
+def test_rule_context_migrate_moves_source_to_target_and_traces() -> None:
+    ctx = _rule_context(current_rule="migrate_rule")
+    source = {"legacy": "value", "other": "kept"}
+    target: dict[str, str] = {}
+
+    ctx.migrate(source, source_key="legacy", target=target, target_key="modern", path="modern")
+
+    assert source == {"other": "kept"}
+    assert target == {"modern": "value"}
+    assert len(ctx.traces) == 1
+    assert ctx.traces[0].rule == "migrate_rule"
+    assert ctx.traces[0].action == "migrate"
+    assert ctx.traces[0].path == "modern"
+
+
+@pytest.mark.fast
+def test_rule_context_migrate_preserves_explicit_target_and_removes_source() -> None:
+    ctx = _rule_context()
+    source = {"legacy": "default"}
+    target = {"modern": "explicit"}
+
+    ctx.migrate(source, source_key="legacy", target=target, target_key="modern", path="modern")
+
+    assert source == {}
+    assert target == {"modern": "explicit"}
+    assert len(ctx.traces) == 1
+    assert ctx.traces[0].action == "migrate"
+    assert ctx.traces[0].path == "modern"
+
+
+@pytest.mark.fast
+def test_rule_context_replace_subtree_replaces_value_and_traces() -> None:
+    ctx = _rule_context(current_rule="replace_rule")
+    target = {"node": {"old": True}}
+
+    ctx.replace_subtree(target, key="node", value={"new": True}, path="node")
+
+    assert target == {"node": {"new": True}}
+    assert len(ctx.traces) == 1
+    assert ctx.traces[0].rule == "replace_rule"
+    assert ctx.traces[0].action == "replace_subtree"
+    assert ctx.traces[0].path == "node"
+
+
+@pytest.mark.fast
+def test_rule_context_fail_includes_provided_path_in_error_message() -> None:
+    ctx = _rule_context()
+
+    with pytest.raises(SmartDefaultsError, match="Cannot infer default at nested.value"):
+        ctx.fail("Cannot infer default", path="nested.value")
+
+
+@pytest.mark.fast
+def test_registered_rule_accepts_description_payload_context_and_uses_caller_context() -> None:
+    @smart_default(
+        scene="static",
+        phase="contract",
+        priority=10,
+        name="contract_rule",
+        description="Exercise the public smart-default rule contract.",
+    )
+    def contract_rule(payload: dict, ctx: RuleContext) -> None:
+        assert ctx.current_rule == "contract_rule"
+        ctx.fill(payload, key="added", value=ctx.current_rule, path="added")
+
+    raw = {"kind": "PipelineConfig", "scene": "static"}
+    profile = select_smart_defaults_profile(raw, Path("config.yaml"))
+    profile = type(profile)(scene=profile.scene, phases=("contract",), rules=profile.rules)
+    ctx = RuleContext(source_path=Path("config.yaml"), cli_intent={"flag": True}, scene=profile.scene)
+
+    expanded = apply_smart_defaults(raw, ctx, profile)
+
+    assert raw == {"kind": "PipelineConfig", "scene": "static"}
+    assert expanded["added"] == "contract_rule"
+    assert ctx.source_path == Path("config.yaml")
+    assert ctx.cli_intent == {"flag": True}
+    assert ctx.current_rule == "contract_rule"
+    assert ctx.traces[0].rule == "contract_rule"
+    assert ctx.traces[0].action == "fill"
+    assert ctx.traces[0].path == "added"
+
+
+@pytest.mark.fast
+def test_agent_and_game_profiles_are_empty_noop_even_with_registered_rules() -> None:
+    @smart_default(
+        scene="agent",
+        phase="contract",
+        priority=10,
+        name="agent_rule",
+        description="Should not run in Phase 0.",
+    )
+    def agent_rule(payload: dict, ctx: RuleContext) -> None:
+        ctx.fill(payload, key="agent_added", value=True, path="agent_added")
+
+    @smart_default(
+        scene="game",
+        phase="contract",
+        priority=10,
+        name="game_rule",
+        description="Should not run in Phase 0.",
+    )
+    def game_rule(payload: dict, ctx: RuleContext) -> None:
+        ctx.fill(payload, key="game_added", value=True, path="game_added")
+
+    for scene in ("agent", "game"):
+        raw = {"kind": "PipelineConfig", "scene": scene}
+        profile = select_smart_defaults_profile(raw, Path(f"{scene}.yaml"))
+        ctx = RuleContext(source_path=Path(f"{scene}.yaml"), cli_intent=None, scene=profile.scene)
+
+        expanded = apply_smart_defaults(raw, ctx, profile)
+
+        assert profile.phases == ()
+        assert profile.rules == ()
+        assert expanded == raw
+        assert ctx.traces == []
+        assert ctx.current_rule == "<unknown>"
+
+
+@pytest.mark.fast
+def test_legacy_no_scene_profile_is_empty_noop() -> None:
+    raw = {"kind": "PipelineConfig", "metadata": {"name": "legacy"}}
+    profile = select_smart_defaults_profile(raw, Path("legacy.yaml"))
+    ctx = RuleContext(source_path=Path("legacy.yaml"), cli_intent=None, scene=profile.scene)
+
+    expanded = apply_smart_defaults(raw, ctx, profile)
+
+    assert profile.scene == "legacy"
+    assert profile.phases == ()
+    assert profile.rules == ()
+    assert expanded == raw
+    assert ctx.traces == []

--- a/tests/unit/config/test_static_smart_defaults_dataset_backend.py
+++ b/tests/unit/config/test_static_smart_defaults_dataset_backend.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from gage_eval.config.loader import materialize_pipeline_config_payload
+from gage_eval.config.smart_defaults import SmartDefaultsError
+
+
+def _base_static_payload() -> dict:
+    return {
+        "kind": "PipelineConfig",
+        "scene": "static",
+        "metadata": {"name": "aime24"},
+        "datasets": [
+            {
+                "dataset_id": "aime24_ds",
+                "hub_id": "Maxwell-Jia/AIME_2024",
+                "split": "train",
+                "params": {"preprocess": "aime2024_preprocessor"},
+            }
+        ],
+        "backends": [
+            {
+                "backend_id": "openai",
+                "type": "litellm",
+                "config": {"api_base": "https://api.openai.com/v1", "model": "gpt-4.1"},
+            }
+        ],
+        "role_adapters": [{"adapter_id": "dut_openai", "role_type": "dut_model", "backend_id": "openai"}],
+        "custom": {"steps": [{"step": "inference", "adapter_id": "dut_openai"}]},
+    }
+
+
+@pytest.mark.fast
+def test_static_dataset_hub_sugar_is_lowered_to_hub_params() -> None:
+    normalized = materialize_pipeline_config_payload(_base_static_payload(), source_path=None)
+
+    dataset = normalized["datasets"][0]
+    assert dataset["hub"] == "huggingface"
+    assert dataset["loader"] == "hf_hub"
+    assert dataset["hub_params"] == {"hub_id": "Maxwell-Jia/AIME_2024", "split": "train"}
+    assert dataset["params"]["preprocess_kwargs"] == {}
+    assert "hub_id" not in dataset
+    assert "split" not in dataset
+
+
+@pytest.mark.fast
+def test_static_litellm_defaults_are_filled_without_generation_params() -> None:
+    normalized = materialize_pipeline_config_payload(_base_static_payload(), source_path=None)
+
+    config = normalized["backends"][0]["config"]
+    assert config["provider"] == "openai"
+    assert config["streaming"] is False
+    assert config["max_retries"] == 6
+    assert "generation_parameters" not in config
+
+
+@pytest.mark.fast
+def test_static_vllm_tokenizer_defaults_do_not_fill_inference_tuning_fields() -> None:
+    payload = _base_static_payload()
+    payload["backends"] = [{"backend_id": "vllm_qwen", "type": "vllm", "config": {"model_path": "/models/qwen"}}]
+    payload["role_adapters"][0]["backend_id"] = "vllm_qwen"
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    config = normalized["backends"][0]["config"]
+    assert config["tokenizer_path"] == "/models/qwen"
+    assert config["force_tokenize_prompt"] is True
+    assert config["tokenizer_trust_remote_code"] is True
+    assert "max_tokens" not in config
+    assert "max_model_len" not in config
+    assert "sampling_params" not in config
+
+
+@pytest.mark.fast
+def test_static_local_jsonl_dataset_does_not_receive_empty_hub_params_and_keeps_original_payload() -> None:
+    payload = _base_static_payload()
+    payload["datasets"] = [{"dataset_id": "local_ds", "params": {"path": "tests/data/sample.jsonl"}}]
+    before = deepcopy(payload)
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert normalized["datasets"][0]["loader"] == "jsonl"
+    assert "hub_params" not in normalized["datasets"][0]
+    assert payload == before
+
+
+@pytest.mark.fast
+def test_static_vlm_transformers_backend_is_left_untouched() -> None:
+    payload = _base_static_payload()
+    payload["backends"] = [
+        {
+            "backend_id": "local_vlm",
+            "type": "vlm_transformers",
+            "config": {"model_name_or_path": "/models/qwen-vl"},
+        }
+    ]
+    payload["role_adapters"][0]["backend_id"] = "local_vlm"
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert normalized["backends"][0]["config"] == {"model_name_or_path": "/models/qwen-vl"}
+
+
+@pytest.mark.fast
+def test_static_dataset_hub_params_explicit_values_win() -> None:
+    payload = _base_static_payload()
+    payload["datasets"][0]["hub_params"] = {"hub_id": "explicit/dataset", "subset": "explicit-subset"}
+    payload["datasets"][0]["subset"] = "sugar-subset"
+    payload["datasets"][0]["revision"] = "main"
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert normalized["datasets"][0]["hub_params"] == {
+        "hub_id": "explicit/dataset",
+        "split": "train",
+        "subset": "explicit-subset",
+        "revision": "main",
+    }
+    assert "subset" not in normalized["datasets"][0]
+    assert "revision" not in normalized["datasets"][0]
+
+
+@pytest.mark.fast
+def test_static_dataset_hub_params_must_be_mapping() -> None:
+    payload = _base_static_payload()
+    payload["datasets"][0]["hub_params"] = "bad"
+
+    with pytest.raises(SmartDefaultsError, match="dataset.hub_params must be a mapping"):
+        materialize_pipeline_config_payload(payload, source_path=None)

--- a/tests/unit/config/test_static_smart_defaults_role_task.py
+++ b/tests/unit/config/test_static_smart_defaults_role_task.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from gage_eval.config.loader import materialize_pipeline_config_payload
+from gage_eval.config.loader_cli import CLIIntent
+from gage_eval.config.smart_defaults import SmartDefaultsError
+
+
+def _short_static_payload() -> dict:
+    return {
+        "api_version": "gage/v1alpha1",
+        "kind": "PipelineConfig",
+        "scene": "static",
+        "metadata": {"name": "aime24"},
+        "datasets": [
+            {
+                "dataset_id": "aime24_ds",
+                "hub_id": "Maxwell-Jia/AIME_2024",
+                "split": "train",
+            }
+        ],
+        "backends": [
+            {
+                "backend_id": "openai",
+                "type": "litellm",
+                "config": {"provider": "openai", "model": "gpt-4.1"},
+            }
+        ],
+        "metrics": ["aime2024_accuracy"],
+        "task": {"max_samples": 30},
+    }
+
+
+@pytest.mark.fast
+def test_short_static_payload_materializes_implicit_single_dut_steps_task_and_reporting() -> None:
+    normalized = materialize_pipeline_config_payload(_short_static_payload(), source_path=None)
+
+    assert normalized["role_adapters"] == [
+        {
+            "adapter_id": "dut_openai",
+            "role_type": "dut_model",
+            "backend_id": "openai",
+            "capabilities": ["chat_completion"],
+        }
+    ]
+    assert normalized["custom"]["steps"] == [{"step": "inference"}, {"step": "auto_eval"}]
+    assert normalized["tasks"][0]["task_id"] == "aime24"
+    assert normalized["tasks"][0]["dataset_id"] == "aime24_ds"
+    assert normalized["tasks"][0]["max_samples"] == 30
+    assert normalized["tasks"][0]["steps"][0]["adapter_id"] == "dut_openai"
+    assert normalized["tasks"][0]["reporting"]["sinks"] == [{"type": "console"}, {"type": "file"}]
+    assert "task" not in normalized
+    assert "backend" not in normalized["tasks"][0]
+
+
+@pytest.mark.fast
+def test_static_smart_defaults_do_not_mutate_original_payload() -> None:
+    payload = _short_static_payload()
+    before = deepcopy(payload)
+
+    materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert payload == before
+
+
+@pytest.mark.fast
+def test_explicit_empty_tasks_are_preserved() -> None:
+    payload = _short_static_payload()
+    payload.pop("task")
+    payload["tasks"] = []
+    payload["role_adapters"] = [
+        {
+            "adapter_id": "dut_openai",
+            "role_type": "dut_model",
+            "backend_id": "openai",
+            "capabilities": ["chat_completion"],
+        }
+    ]
+    payload["custom"] = {"steps": [{"step": "inference", "adapter_id": "dut_openai"}]}
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert normalized["tasks"] == []
+
+
+@pytest.mark.fast
+def test_explicit_empty_role_adapters_still_generates_dut_adapters() -> None:
+    payload = _short_static_payload()
+    payload["role_adapters"] = []
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert normalized["role_adapters"] == [
+        {
+            "adapter_id": "dut_openai",
+            "role_type": "dut_model",
+            "backend_id": "openai",
+            "capabilities": ["chat_completion"],
+        }
+    ]
+
+
+@pytest.mark.fast
+def test_cli_backend_id_overrides_task_backend_for_dut_adapter_binding() -> None:
+    payload = _short_static_payload()
+    payload["backends"].append(
+        {"backend_id": "vllm_qwen", "type": "vllm", "config": {"model_path": "/models/qwen"}}
+    )
+    payload["task"]["backend"] = "openai"
+
+    normalized = materialize_pipeline_config_payload(
+        payload,
+        source_path=None,
+        cli_intent=CLIIntent(backend_id="vllm_qwen"),
+    )
+
+    assert normalized["tasks"][0]["steps"][0]["adapter_id"] == "dut_vllm_qwen"
+
+
+@pytest.mark.fast
+def test_task_backend_expand_rejects_unknown_backend() -> None:
+    payload = _short_static_payload()
+    payload["task"]["backend"] = "missing"
+
+    with pytest.raises(SmartDefaultsError) as excinfo:
+        materialize_pipeline_config_payload(payload, source_path=None)
+
+    message = str(excinfo.value)
+    assert "cannot find unique DUT adapter" in message
+    assert "tasks[0].backend" in message
+
+
+@pytest.mark.fast
+def test_cli_backend_id_rejects_unknown_backend_with_cli_path() -> None:
+    payload = _short_static_payload()
+
+    with pytest.raises(SmartDefaultsError) as excinfo:
+        materialize_pipeline_config_payload(
+            payload,
+            source_path=None,
+            cli_intent=CLIIntent(backend_id="missing"),
+        )
+
+    message = str(excinfo.value)
+    assert "cannot find unique DUT adapter" in message
+    assert "cli.backend_id" in message
+    assert "tasks[0].backend" not in message
+
+
+@pytest.mark.fast
+def test_task_backend_from_single_dut_rejects_ambiguous_backend() -> None:
+    payload = _short_static_payload()
+    payload["backends"].append(
+        {"backend_id": "vllm_qwen", "type": "vllm", "config": {"model_path": "/models/qwen"}}
+    )
+
+    with pytest.raises(SmartDefaultsError, match="does not have exactly one DUT adapter"):
+        materialize_pipeline_config_payload(payload, source_path=None)
+
+
+@pytest.mark.fast
+def test_auto_custom_steps_does_not_apply_to_judge_adapter() -> None:
+    payload = _short_static_payload()
+    payload["role_adapters"] = [
+        {"adapter_id": "dut_openai", "role_type": "dut_model", "backend_id": "openai"},
+        {"adapter_id": "judge", "role_type": "judge_model", "backend_id": "openai"},
+    ]
+
+    with pytest.raises(Exception, match="custom|steps|pipeline"):
+        materialize_pipeline_config_payload(payload, source_path=None)
+
+
+@pytest.mark.fast
+def test_auto_custom_steps_fills_steps_when_custom_mapping_exists_without_steps() -> None:
+    payload = _short_static_payload()
+    payload["custom"] = {"metadata": {"owner": "test"}}
+
+    normalized = materialize_pipeline_config_payload(payload, source_path=None)
+
+    assert normalized["custom"]["steps"] == [{"step": "inference"}, {"step": "auto_eval"}]
+    assert normalized["custom"]["metadata"] == {"owner": "test"}

--- a/tests/unit/test_run_env_expansion.py
+++ b/tests/unit/test_run_env_expansion.py
@@ -24,3 +24,29 @@ def test_expand_env_required_placeholder_reports_message(monkeypatch):
 
     with pytest.raises(ValueError, match="set OPENAI_API_KEY"):
         run._expand_env({"api_key": "${OPENAI_API_KEY:?set OPENAI_API_KEY}"})
+
+
+def test_apply_cli_metric_filter_preserves_malformed_entries_for_schema_validation():
+    payload = {"metrics": ["keep", 123]}
+
+    run._apply_cli_metric_filter(payload, "keep")
+
+    assert payload["metrics"] == ["keep", 123]
+
+
+def test_apply_cli_skip_judge_removes_custom_and_task_steps():
+    payload = {
+        "custom": {"steps": [{"step": "inference"}, {"step": "judge"}, {"step": "auto_eval"}]},
+        "tasks": [
+            {
+                "task_id": "t1",
+                "dataset_id": "ds",
+                "steps": [{"step": "inference"}, {"step": "judge"}],
+            }
+        ],
+    }
+
+    run._apply_cli_skip_judge(payload)
+
+    assert payload["custom"]["steps"] == [{"step": "inference"}, {"step": "auto_eval"}]
+    assert payload["tasks"][0]["steps"] == [{"step": "inference"}]

--- a/tests/unit/tools/test_config_checker_loader.py
+++ b/tests/unit/tools/test_config_checker_loader.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gage_eval.tools.config_checker import validate_config
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.io
+def test_config_checker_accepts_short_static_config() -> None:
+    path = ROOT / "tests" / "fixtures" / "static_eval" / "aime24_short.yaml"
+
+    validate_config(path, materialize_runtime=False)


### PR DESCRIPTION
* feat(config): add static smart defaults

Add static scene smart-default rules, loader materialization, CLI intent overrides, and show-expanded-config support.

Add simplified AIME/SimpleQA configs, user guide documentation, and focused unit/integration coverage.

* fix(arena): restore passing game arena tests

Preserve move_count when deriving arena total_steps, align realtime config assertions with current retro_mario settings, and sync the arena registry manifest.