### PR TITLE
User/pk/litellm backend (#162)

### DIFF
--- a/docs/guide/framework_overview_zh.md
+++ b/docs/guide/framework_overview_zh.md
@@ -13,6 +13,7 @@ gage-eval 是一个可扩展的大模型评测框架。它以 **Step 链路** �
 - 测试体系：[`TESTING.md`](../../TESTING.md)
 - 示例配置：[`config/custom/`](../../config/custom/)、[`config/builtin_templates/`](../../config/builtin_templates/)、[`config/run_configs/`](../../config/run_configs/)
 - Sample 契约：[`sample_zh.md`](sample_zh.md)（标准化 Sample 设计）
+- LiteLLM Backend：[`litellm_backend_enhancements_zh.md`](litellm_backend_enhancements_zh.md)（vLLM/LiteLLM 增强能力与配置指南）
 - Agent 评测：[`agent_evaluation_zh.md`](agent_evaluation_zh.md)（AgentKitV2 原生评测指南）
 - External Harness：[`external_harness_zh.md`](external_harness_zh.md)（Harbor 委托运行指南）
 - Game Arena：[`game_arena_zh.md`](game_arena_zh.md)（对战评测模块）

--- a/docs/guide/litellm_backend_enhancements_zh.md
+++ b/docs/guide/litellm_backend_enhancements_zh.md
@@ -1,0 +1,653 @@
+# LiteLLM Backend 增强指南
+
+中文 | English: 暂无
+
+本文说明 GAGE `litellm` backend 的增强能力、推荐配置方式、常见 vLLM 部署形态，以及排错和实机验证要点。文档中的命令默认在 `gage-eval-main/` 仓库根目录执行。
+
+> 适用对象：需要用 GAGE 通过 LiteLLM 调用 OpenAI-compatible 服务、vLLM server、LiteLLM Gateway，或需要验证 thinking、多模态、工具调用、streaming/async 等能力的评测配置作者。
+
+## 0. 相关入口
+
+- 配置 schema：`src/gage_eval/role/model/config/litellm.py`
+- backend 主入口：`src/gage_eval/role/model/backends/litellm_backend.py`
+- LiteLLM 子模块：
+  - `src/gage_eval/role/model/backends/litellm/request_builder.py`
+  - `src/gage_eval/role/model/backends/litellm/message_normalizer.py`
+  - `src/gage_eval/role/model/backends/litellm/response_normalizer.py`
+  - `src/gage_eval/role/model/backends/litellm/policies.py`
+  - `src/gage_eval/role/model/backends/litellm/router_factory.py`
+  - `src/gage_eval/role/model/backends/litellm/model_server_lifecycle.py`
+- 配置校验：
+
+```bash
+PYTHONPATH=src python -m gage_eval.tools.config_checker \
+  --config config/custom/examples/qwen3_vllm_piqa_messages_no_thinking.yaml
+```
+
+## 1. 能力概览
+
+`litellm` backend 现在既可以作为普通远程模型后端，也可以作为 vLLM OpenAI-compatible server 的统一适配层。主要增强点如下：
+
+| 能力 | 支持情况 | 关键配置 |
+| --- | --- | --- |
+| 单 endpoint 直连 | 支持 | `route_mode: direct`, `provider: hosted_vllm`, `api_base` |
+| 多 endpoint 聚合 | 支持 | `route_mode: router`, `model_list`, `router_settings` |
+| 外部 LiteLLM Gateway | 支持 | 指向 Gateway 的 `api_base`，`vllm.topology.kind: external_litellm_gateway` |
+| thinking/no-thinking | 支持 | `generation_parameters.thinking_mode`, `thinking_policy`, `vllm.reasoning_parser` |
+| `reasoning_content` 归一化 | 支持 | response normalizer 自动提取 |
+| 多模态 content blocks | 支持 text/image/audio 保真 | `multimodal.*`, `vllm.topology.language_model_only` |
+| 工具调用 | 支持 | `tool_calling.*`, 样本级 `tools`, `tool_choice` |
+| 结构化输出 | 支持 | `litellm_request.response_format` |
+| sync streaming | 支持 | `streaming: true`, `litellm_request.stream_options` |
+| async 调用 | 支持 backend `ainvoke` | 由 RoleAdapter 或直接探针调用 |
+| 请求级透传 | 支持 | `litellm_request.*` |
+| retry ownership | 支持 | Router/Gateway 场景自动收敛外层 retry |
+| 实验性 server 生命周期 | 支持命令模式 | `model_server.enabled`, `startup_command`, `health.urls` |
+
+整体调用链：
+
+```mermaid
+flowchart LR
+  classDef cfg fill:#E8F3FF,stroke:#2F80ED,color:#143A5A
+  classDef gage fill:#F4ECFF,stroke:#7B61FF,color:#2E1A67
+  classDef ext fill:#E9F8EF,stroke:#27AE60,color:#174A2A
+  classDef warn fill:#FFF4D6,stroke:#F2A900,color:#5A3B00
+
+  YAML["PipelineConfig"]:::cfg --> Adapter["ModelRoleAdapter"]:::gage
+  Adapter --> Backend["LiteLLMBackend"]:::gage
+  Backend --> Builder["RequestBuilder"]:::gage
+  Backend --> MM["MessageNormalizer"]:::gage
+  Backend --> Resp["ResponseNormalizer"]:::gage
+  Backend --> Router{"route_mode"}:::warn
+  Router -- direct --> Completion["litellm.completion / acompletion"]:::ext
+  Router -- router --> LiteRouter["litellm.Router"]:::ext
+  Completion --> VLLM["vLLM OpenAI-compatible endpoint"]:::ext
+  LiteRouter --> VLLM
+```
+
+## 2. 推荐部署 Profile
+
+### 2.1 P1 direct：单 vLLM endpoint
+
+适用于单机单卡、单机多卡单副本、或多机多卡但只暴露一个 head API endpoint 的 vLLM 服务。
+
+vLLM server 示例：
+
+```bash
+vllm serve /mnt/model/Qwen3.6-35B-A3B \
+  --served-model-name qwen3-p1 \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --trust-remote-code \
+  --tensor-parallel-size 1 \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_xml \
+  --default-chat-template-kwargs '{"enable_thinking": true}'
+```
+
+GAGE backend 示例：
+
+```yaml
+backends:
+  - backend_id: qwen3_litellm_direct
+    type: litellm
+    config:
+      provider: hosted_vllm
+      custom_llm_provider: hosted_vllm
+      model: hosted_vllm/qwen3-p1
+      api_base: http://127.0.0.1:8000/v1
+      api_key: EMPTY
+      streaming: false
+      drop_params: true
+      max_retries: 2
+      generation_parameters:
+        max_new_tokens: 256
+        temperature: 0.0
+      vllm:
+        reasoning_parser: qwen3
+        topology:
+          kind: external_endpoint
+          language_model_only: false
+```
+
+注意：
+
+- `api_base` 应停在 `/v1`，不要写成 `/v1/chat/completions`。
+- `model` 建议使用 `hosted_vllm/<served-model-name>`，与 vLLM `--served-model-name` 对齐。
+- `drop_params: true` 可以保留；GAGE 会把 vLLM thinking 开关放入 `extra_body.chat_template_kwargs`，避免顶层未知参数被 LiteLLM 丢弃。
+
+### 2.2 P2 internal Router：多个 vLLM endpoint 聚合
+
+适用于单机多卡多副本、或多组 vLLM endpoint 的负载分发和副本隔离。GAGE 在 backend 内部创建 LiteLLM Router，不需要额外启动 LiteLLM Gateway。
+
+```yaml
+backends:
+  - backend_id: qwen3_litellm_router
+    type: litellm
+    config:
+      provider: hosted_vllm
+      custom_llm_provider: hosted_vllm
+      route_mode: router
+      model: hosted_vllm/qwen3-router
+      api_key: EMPTY
+      streaming: false
+      drop_params: true
+      generation_parameters:
+        max_new_tokens: 128
+        temperature: 0.0
+      model_list:
+        - model_name: qwen3-router
+          litellm_params:
+            model: hosted_vllm/qwen3-r1
+            api_base: http://127.0.0.1:8001/v1
+            api_key: EMPTY
+          vllm:
+            reasoning_parser: qwen3
+            topology:
+              language_model_only: false
+        - model_name: qwen3-router
+          litellm_params:
+            model: hosted_vllm/qwen3-r2
+            api_base: http://127.0.0.1:8002/v1
+            api_key: EMPTY
+          vllm:
+            reasoning_parser: qwen3
+            topology:
+              language_model_only: false
+      router_settings:
+        routing_strategy: simple-shuffle
+        allowed_fails: 1
+        cooldown_time: 10
+        num_retries: 2
+      vllm:
+        reasoning_parser: qwen3
+        topology:
+          kind: internal_router
+          language_model_only: false
+```
+
+Router 场景的约束：
+
+- 同一个 `model_name` 组内的 `reasoning_parser`、chat template 默认值、`language_model_only` 应保持一致。
+- 如果配置里提供了 per-deployment `vllm` 元数据，GAGE 会检查不一致并 fail fast。
+- 如果只提供顶层 `vllm` 元数据，GAGE 会假定所有 deployment 遵守同一部署纪律。
+
+### 2.3 外部 LiteLLM Gateway
+
+如果已经有独立 LiteLLM Gateway，可让 GAGE 直连 Gateway：
+
+```yaml
+backends:
+  - backend_id: qwen3_litellm_gateway
+    type: litellm
+    config:
+      provider: litellm_gateway
+      custom_llm_provider: hosted_vllm
+      model: hosted_vllm/qwen3-gateway
+      api_base: http://127.0.0.1:4000/v1
+      api_key: EMPTY
+      max_retries: 6
+      generation_parameters:
+        max_new_tokens: 128
+        temperature: 0.0
+      vllm:
+        topology:
+          kind: external_litellm_gateway
+```
+
+GAGE 会把 Gateway 识别为外部路由层，并把本 backend 的外层 retry budget 收敛到 1，避免 Gateway retry 与 GAGE retry 叠加放大尾延迟。
+
+## 3. Thinking / No-thinking
+
+### 3.1 推荐配置
+
+Qwen3 + vLLM 的 thinking 开关应走 `extra_body.chat_template_kwargs.enable_thinking`。配置作者只需要声明 `thinking_mode`：
+
+```yaml
+config:
+  provider: hosted_vllm
+  custom_llm_provider: hosted_vllm
+  model: hosted_vllm/qwen3-p1
+  api_base: http://127.0.0.1:8000/v1
+  drop_params: true
+  generation_parameters:
+    max_new_tokens: 256
+    temperature: 0.6
+    thinking_mode: enabled   # enabled / disabled / auto
+  thinking_policy:
+    capability: supported
+    on_unsupported: fail_fast
+    on_mismatch: warn_and_continue
+    record_effective_state: true
+  vllm:
+    reasoning_parser: qwen3
+```
+
+no-thinking：
+
+```yaml
+generation_parameters:
+  max_new_tokens: 128
+  temperature: 0.0
+  thinking_mode: disabled
+```
+
+GAGE 会在请求构造时把它转换为：
+
+```yaml
+extra_body:
+  chat_template_kwargs:
+    enable_thinking: false
+```
+
+### 3.2 鲁棒性策略
+
+模型和 server 侧可能出现四类情况：
+
+| 情况 | GAGE 行为 |
+| --- | --- |
+| 模型支持 thinking，server 开了 `--reasoning-parser qwen3` | 正常提取 `reasoning_content` 和 `reasoning_details` |
+| 配置要求 no-thinking | 注入 `enable_thinking=false`，且不会触发 reasoning 模型 `max_tokens * 10` 放大 |
+| 配置要求 thinking，但 profile 声明不支持 | 按 `thinking_policy.on_unsupported` 决定 warn、ignore 或 fail fast |
+| 响应与期望不一致 | 写入 `metadata.thinking_mismatch`，按 `on_mismatch` 决定 warn 或 fail fast |
+
+响应归一化会尝试从以下位置提取 reasoning：
+
+- `message.reasoning_content`
+- `message.reasoning_details`
+- `<think>...</think>` 标签
+- usage/raw response 中的 `reasoning_tokens` 作为观测信号
+
+输出字段：
+
+```json
+{
+  "answer": "...",
+  "reasoning_content": "...",
+  "reasoning_details": [],
+  "metadata": {
+    "thinking_mode": "disabled",
+    "thinking_effective": "enabled",
+    "thinking_mismatch": {
+      "expected": "disabled",
+      "observed": "enabled",
+      "error_type": "response_mismatch"
+    }
+  }
+}
+```
+
+## 4. 多模态
+
+`litellm` backend 注册的 modalities 包含 `text`, `vision`, `audio`。消息归一化会保留 OpenAI content blocks，并处理 vLLM/OpenAI-compatible 常见输入形态。
+
+图片样本：
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Describe this image."},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+      ]
+    }
+  ]
+}
+```
+
+音频样本：
+
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Transcribe this audio."},
+        {"type": "input_audio", "input_audio": {"data": "...", "format": "wav"}}
+      ]
+    }
+  ]
+}
+```
+
+backend 配置：
+
+```yaml
+multimodal:
+  fallback: fail
+  audio_url_mapping: input_audio
+  default_audio_format: wav
+  max_media_bytes: 5242880
+vllm:
+  topology:
+    language_model_only: false
+```
+
+关键边界：
+
+- `fallback: fail` 是推荐值，遇到不支持的媒体块时直接失败，避免静默退化为文本。
+- `max_media_bytes` 只做轻量大小保护，避免大体积 base64 进入请求链路。
+- 如果 vLLM server 使用 `--language-model-only`，应在配置中声明 `vllm.topology.language_model_only: true`。GAGE 会在发送多模态请求前拒绝，错误类型为 `unsupported_capability`。
+
+## 5. 工具调用
+
+工具定义可放在样本级 `tools`，`tool_choice` 和 `parallel_tool_calls` 可放在样本级或 backend 配置中。
+
+样本示例：
+
+```json
+{
+  "id": "tool_call_001",
+  "messages": [
+    {"role": "user", "content": "Call get_weather for Shanghai."}
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather for a city.",
+        "parameters": {
+          "type": "object",
+          "properties": {"city": {"type": "string"}},
+          "required": ["city"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto"
+}
+```
+
+backend 配置：
+
+```yaml
+tool_calling:
+  enabled: true
+  auto_tool_choice: true
+  parallel_tool_calls: true
+  require_server_parser: true
+  expected_tool_parser: qwen3_xml
+  expected_server_flags:
+    enable_auto_tool_choice: true
+    tool_call_parser: qwen3_xml
+litellm_request:
+  parallel_tool_calls: true
+```
+
+vLLM server 需要匹配：
+
+```bash
+--enable-auto-tool-choice --tool-call-parser qwen3_xml
+```
+
+响应中 `tool_calls` 会被归一化，`function.arguments` 会尽量解析为 JSON dict；如果 arguments 是坏 JSON，会保留原始字符串到 `raw_arguments`，避免信息丢失。
+
+## 6. 结构化输出、Streaming 与 Async
+
+### 6.1 JSON mode
+
+```yaml
+litellm_request:
+  response_format:
+    type: json_object
+generation_parameters:
+  max_new_tokens: 128
+  temperature: 0.0
+```
+
+GAGE 不再硬编码 `response_format: {"type": "text"}`。是否严格返回合法 JSON 仍取决于模型和 vLLM server 的结构化输出支持。
+
+### 6.2 Sync streaming
+
+```yaml
+streaming: true
+litellm_request:
+  stream_options:
+    include_usage: true
+```
+
+stream chunks 会被聚合成单个 GAGE result：
+
+```json
+{
+  "answer": "...",
+  "raw_response": ["...chunks..."],
+  "usage": {},
+  "finish_reason": "stop"
+}
+```
+
+### 6.3 Async
+
+`LiteLLMBackend.ainvoke()` 使用 LiteLLM `acompletion`。在常规 PipelineConfig 中，是否走 async 取决于上层 RoleAdapter/Runtime 调用路径；需要直接验证 backend async 时，可以在测试或探针中直接调用：
+
+```python
+import asyncio
+from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
+
+async def main():
+    backend = LiteLLMBackend({
+        "provider": "hosted_vllm",
+        "custom_llm_provider": "hosted_vllm",
+        "model": "hosted_vllm/qwen3-p1",
+        "api_base": "http://127.0.0.1:8000/v1",
+        "api_key": "EMPTY",
+        "streaming": True,
+        "generation_parameters": {"max_new_tokens": 64, "temperature": 0.0},
+    })
+    result = await backend.ainvoke({
+        "sample": {
+            "messages": [{"role": "user", "content": "Reply with OK."}]
+        }
+    })
+    print(result["answer"])
+
+asyncio.run(main())
+```
+
+## 7. 请求透传配置
+
+`litellm_request` 是面向 LiteLLM completion 参数的显式透传区。支持字段：
+
+| 字段 | 用途 |
+| --- | --- |
+| `response_format` | JSON mode 或其他结构化输出控制 |
+| `max_completion_tokens` | 兼容部分 provider 的 token 字段 |
+| `stream_options` | streaming 附加参数，例如 `include_usage` |
+| `parallel_tool_calls` | 多工具并行控制 |
+| `logit_bias` | token bias |
+| `user` | end-user 标识 |
+| `metadata` | 请求 metadata |
+| `fallbacks` | LiteLLM fallback 配置 |
+| `context_window_fallback_dict` | 上下文窗口 fallback |
+| `extra_body` | provider/server 专用 body，例如 `chat_template_kwargs` |
+| `drop_params` | 请求级覆盖 LiteLLM drop params 行为 |
+
+这些字段也可以通过样本或 payload 的 `sampling_params` 临时覆盖，适合对少量样本做局部实验。
+
+## 8. Retry、错误分类与可观测性
+
+### 8.1 Retry ownership
+
+GAGE 避免多层 retry 叠加：
+
+| 场景 | retry owner | GAGE backend 行为 |
+| --- | --- | --- |
+| direct endpoint | GAGE LiteLLM backend | 使用 `max_retries` |
+| internal Router | LiteLLM Router | 外层 retry budget 收敛到 1 |
+| external LiteLLM Gateway | Gateway | 外层 retry budget 收敛到 1 |
+
+Router retry 配在：
+
+```yaml
+router_settings:
+  routing_strategy: simple-shuffle
+  allowed_fails: 1
+  cooldown_time: 10
+  num_retries: 2
+```
+
+### 8.2 错误分类
+
+backend 会把常见失败归一化为结构化错误：
+
+| error_type | 常见来源 |
+| --- | --- |
+| `dependency_unavailable` | endpoint 不可达、server health timeout、依赖不可用 |
+| `invalid_request` | `api_base` 写到具体 endpoint、请求参数非法 |
+| `unsupported_capability` | 多模态请求发往 `language_model_only` server、工具能力不满足 |
+| `response_mismatch` | thinking 期望与响应观测不一致 |
+| `invalid_media_payload` / `media_payload_too_large` | 媒体块格式或大小不合规 |
+| `invalid_tool_arguments` | tool call arguments 不是合法 JSON |
+
+### 8.3 观测摘要
+
+响应归一化会生成脱敏观测摘要，用于调试：
+
+- `provider`, `model`, `api_base_hash`
+- `route_mode`, `topology`
+- thinking mode 与 effective state
+- modality counts
+- tool count / tool call count
+- retry owner
+- finish reason, usage, latency
+
+摘要中不会输出完整 API key 或完整 base64 媒体。
+
+## 9. 实验性 ModelServerLifecycle
+
+`model_server` 是实验性功能，目标是在评测运行时先执行一段用户提供的 bash 命令启动本地模型服务，等 health URL 可用后再调用 LiteLLM。
+
+```yaml
+model_server:
+  enabled: true
+  startup_command: |
+    mkdir -p ${GAGE_VLLM_LOG_DIR:-/tmp/gage-vllm}
+    nohup vllm serve ${GAGE_MODEL_PATH:-/mnt/model/Qwen3.6-35B-A3B} \
+      --served-model-name ${GAGE_VLLM_P1_MODEL:-qwen3-p1} \
+      --host 0.0.0.0 \
+      --port ${GAGE_VLLM_P1_PORT:-8000} \
+      --trust-remote-code \
+      --reasoning-parser qwen3 \
+      --enable-auto-tool-choice \
+      --tool-call-parser qwen3_xml \
+      > ${GAGE_VLLM_LOG_DIR:-/tmp/gage-vllm}/vllm.log 2>&1 &
+  health:
+    urls:
+      - http://127.0.0.1:8000/v1/models
+    timeout_seconds: 900
+    interval_seconds: 5
+```
+
+限制：
+
+- 命令通过 `bash -lc` 执行。
+- 框架只负责启动和 health-gate，不负责日志轮转、资源回收、端口治理或进程编排。
+- `startup_command` 会做基础危险命令拦截，例如 `curl | bash`、`wget | sh`、`rm -rf /`、`mkfs`。
+- health 超时会归类为 `dependency_unavailable`。
+
+生产或长时间压测仍建议由外部进程管理器、容器平台或作业系统管理 vLLM server。
+
+## 10. 完整配置骨架
+
+下面是一个包含主要增强点的骨架。实际评测时按需删减。
+
+```yaml
+backends:
+  - backend_id: qwen3_litellm
+    type: litellm
+    config:
+      provider: hosted_vllm
+      custom_llm_provider: hosted_vllm
+      route_mode: direct
+      model: hosted_vllm/qwen3-p1
+      api_base: http://127.0.0.1:8000/v1
+      api_key: EMPTY
+      extra_headers: {}
+      streaming: false
+      drop_params: true
+      timeout: 120
+      max_retries: 2
+      retry_sleep: 1.0
+      retry_multiplier: 2.0
+      max_model_length: 8192
+      generation_parameters:
+        max_new_tokens: 256
+        temperature: 0.0
+        top_p: 0.95
+        thinking_mode: disabled
+      litellm_request:
+        response_format: null
+        stream_options: null
+        parallel_tool_calls: null
+        extra_body: {}
+        drop_params: null
+      vllm:
+        reasoning_parser: qwen3
+        topology:
+          kind: external_endpoint
+          language_model_only: false
+      thinking_policy:
+        capability: auto
+        on_unsupported: warn_and_continue
+        on_mismatch: warn_and_continue
+        record_effective_state: true
+      multimodal:
+        fallback: fail
+        audio_url_mapping: input_audio
+        default_audio_format: wav
+        max_media_bytes: 5242880
+      tool_calling:
+        enabled: false
+        auto_tool_choice: false
+        parallel_tool_calls: null
+        require_server_parser: false
+        expected_tool_parser: null
+      model_server:
+        enabled: false
+        startup_command: null
+        health:
+          urls: []
+```
+
+## 11. 实机验证建议
+
+建议至少覆盖以下 smoke：
+
+| 场景 | 目的 |
+| --- | --- |
+| 基础 chat | 验证 endpoint、served model、usage、latency |
+| Router 分发 | 验证多 deployment 命中和副本隔离 |
+| thinking on/off | 验证 `extra_body.chat_template_kwargs` 没被 `drop_params` 丢弃 |
+| 多模态 | 验证 image/audio blocks 保真 |
+| 工具调用 | 验证 vLLM tool parser 输出能归一化 |
+| JSON mode | 验证 `response_format` 透传 |
+| sync streaming / async | 验证分片聚合和 `acompletion` |
+| 错误分类 | 验证 dead endpoint、4xx、unsupported capability |
+| 并发 | 验证全局锁已移除后的并行收益 |
+| ModelServerLifecycle | 验证 startup command 与 health-gate |
+
+执行前检查：
+
+```bash
+python - <<'PY'
+import importlib.metadata as md
+for pkg in ("litellm", "vllm"):
+    print(pkg, md.version(pkg))
+PY
+```
+
+最低依赖基线：
+
+```text
+litellm >= 1.63.8
+vllm >= 0.20.1
+```
+
+Mac 本地环境可以用 `vllm 0.21.0+cpu` 做 import 和配置校验；真实 server 行为仍应以 Linux+GPU 环境为准。
+

--- a/registry_manifest.yaml
+++ b/registry_manifest.yaml
@@ -1,3 +1,4 @@
+arena_game_providers: []
 arena_impls: []
 backends: []
 bundles: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ modelscope>=1.13.0
 
 # Remote model backends
 openai>=1.6.0
-litellm>=1.36.0
+litellm>=1.63.8
 anthropic>=0.26.0
 google-generativeai>=0.5.0
 mcp>=1.19.0
@@ -24,7 +24,7 @@ mcp>=1.19.0
 torch>=2.0.0
 transformers>=4.36.0
 accelerate>=0.29.0
-vllm>=0.4.0
+vllm>=0.20.1
 FlagEmbedding>=1.2.7
 faiss-cpu>=1.7.4
 faster-whisper>=0.10.0

--- a/src/gage_eval/role/adapters/model_role_adapter.py
+++ b/src/gage_eval/role/adapters/model_role_adapter.py
@@ -180,3 +180,12 @@ class ModelRoleAdapter(RoleAdapter):
         else:
             response = await ensure_async(self.backend)(request)
         return self.handle_backend_response(payload, response)
+
+    def invoke(self, payload: Dict[str, Any], state: RoleAdapterState) -> Dict[str, Any]:
+        request = self.prepare_backend_request(payload)
+        backend_call = getattr(self.backend, "invoke", None)
+        if backend_call:
+            response = backend_call(request)
+        else:
+            response = run_sync(ensure_async(self.backend)(request))
+        return self.handle_backend_response(payload, response)

--- a/src/gage_eval/role/model/backends/__init__.py
+++ b/src/gage_eval/role/model/backends/__init__.py
@@ -41,6 +41,12 @@ class _AsyncBackendProxy(Backend):
 
         return await ensure_async(self._backend)(payload)
 
+    def invoke(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        backend_call = getattr(self._backend, "invoke", None)
+        if backend_call:
+            return backend_call(payload)
+        return super().invoke(payload)
+
 
 class _HttpRetryBackendProxy(Backend, HttpRetryMixin):
     def __init__(self, backend: Backend, *, attempts: int, interval: float) -> None:
@@ -77,6 +83,22 @@ class _ErrorNormalizingBackendProxy(Backend):
                 return await backend_call(payload)
 
             return await ensure_async(self._backend)(payload)
+        except Exception as exc:
+            backend_name = _resolve_backend_name(self._backend)
+            logger.error(
+                "Backend {} invocation failed error_type={} error={}",
+                backend_name,
+                type(exc).__name__,
+                exc,
+            )
+            return build_backend_error_result(exc, backend_name=backend_name)
+
+    def invoke(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            backend_call = getattr(self._backend, "invoke", None)
+            if backend_call:
+                return backend_call(payload)
+            return super().invoke(payload)
         except Exception as exc:
             backend_name = _resolve_backend_name(self._backend)
             logger.error(

--- a/src/gage_eval/role/model/backends/base_backend.py
+++ b/src/gage_eval/role/model/backends/base_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any, Dict, Optional
 
@@ -64,9 +65,19 @@ def build_backend_error_result(
     return {
         "error": str(exc),
         "status": resolved_status,
-        "error_type": type(exc).__name__,
+        "error_type": _resolve_backend_error_type(exc),
         "backend": backend_name,
     }
+
+
+def _resolve_backend_error_type(exc: Exception) -> str:
+    explicit_type = getattr(exc, "error_type", None)
+    if explicit_type:
+        return str(explicit_type)
+    match = re.search(r"error_type=([A-Za-z0-9_.:-]+)", str(exc))
+    if match:
+        return match.group(1)
+    return type(exc).__name__
 
 
 class EngineBackend(Backend):

--- a/src/gage_eval/role/model/backends/litellm/__init__.py
+++ b/src/gage_eval/role/model/backends/litellm/__init__.py
@@ -1,0 +1,14 @@
+"""LiteLLM backend support modules."""
+
+from __future__ import annotations
+
+from gage_eval.role.model.backends.litellm.policies import ThinkingControlPolicy, ToolCallPolicy
+from gage_eval.role.model.backends.litellm.request_builder import LiteLLMRequestBuilder
+from gage_eval.role.model.backends.litellm.response_normalizer import LiteLLMResponseNormalizer
+
+__all__ = [
+    "LiteLLMRequestBuilder",
+    "LiteLLMResponseNormalizer",
+    "ThinkingControlPolicy",
+    "ToolCallPolicy",
+]

--- a/src/gage_eval/role/model/backends/litellm/credential_resolver.py
+++ b/src/gage_eval/role/model/backends/litellm/credential_resolver.py
@@ -1,0 +1,116 @@
+"""Provider-aware credential resolution for LiteLLM backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+from gage_eval.role.model.backends.litellm.provider_detection import (
+    infer_provider_from_model,
+    is_default_local_litellm_gateway,
+    is_explicit_litellm_gateway,
+    is_local_api_base,
+    normalize_provider_name,
+)
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+
+
+SAFE_DUMMY_API_KEY = "dummy"
+
+
+class ProviderCredentialResolver:
+    """Resolve API keys without leaking one provider's env key to another."""
+
+    _PROVIDER_ENV_KEYS = {
+        "deepseek": ("DEEPSEEK_API_KEY",),
+        "kimi": ("KIMI_API_KEY", "MOONSHOT_API_KEY"),
+        "moonshot": ("KIMI_API_KEY", "MOONSHOT_API_KEY"),
+        "grok": ("XAI_API_KEY", "GROK_API_KEY"),
+        "xai": ("XAI_API_KEY", "GROK_API_KEY"),
+        "azure": ("AZURE_API_KEY", "AZURE_OPENAI_API_KEY"),
+        "azure_openai": ("AZURE_API_KEY", "AZURE_OPENAI_API_KEY"),
+        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "google": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        "anthropic": ("ANTHROPIC_API_KEY",),
+        "openai": ("OPENAI_API_KEY",),
+    }
+
+    _GENERIC_ENV_KEYS = ("LITELLM_API_KEY",)
+    _OPENAI_COMPATIBLE_PROVIDERS = {"hosted_vllm", "vllm", "openai_compatible"}
+
+    def __init__(
+        self,
+        cfg: LiteLLMBackendConfig,
+        *,
+        provider: str | None = None,
+        custom_llm_provider: str | None = None,
+        topology_kind: str | None = None,
+    ) -> None:
+        self._cfg = cfg
+        self._provider = normalize_provider_name(
+            provider or cfg.provider or infer_provider_from_model(cfg.model, include_openai_family=True)
+        )
+        self._custom_llm_provider = normalize_provider_name(custom_llm_provider or cfg.custom_llm_provider)
+        topology = getattr(getattr(cfg, "vllm", None), "topology", None)
+        self._topology_kind = topology_kind if topology_kind is not None else getattr(topology, "kind", None)
+
+    def resolve(self) -> str | None:
+        """Return the effective key, a safe dummy key, or ``None`` when absent."""
+
+        explicit = self._first_present((self._cfg.api_key, self._cfg.mock_api_key))
+        if explicit:
+            return explicit
+
+        env_key = self._first_env(self._env_candidates())
+        if env_key:
+            return env_key
+
+        if self._allows_dummy_key():
+            return SAFE_DUMMY_API_KEY
+        return None
+
+    def _env_candidates(self) -> tuple[str, ...]:
+        provider = self._effective_provider()
+        if is_explicit_litellm_gateway(
+            provider,
+            custom_llm_provider=self._custom_llm_provider,
+            topology_kind=self._topology_kind,
+        ) or is_default_local_litellm_gateway(self._cfg.api_base or self._cfg.mock_api_base):
+            return self._GENERIC_ENV_KEYS
+
+        candidates: list[str] = []
+        candidates.extend(self._PROVIDER_ENV_KEYS.get(provider, ()))
+        if provider == "":
+            candidates.extend(self._GENERIC_ENV_KEYS)
+        elif provider in self._OPENAI_COMPATIBLE_PROVIDERS:
+            candidates.extend(self._GENERIC_ENV_KEYS)
+        elif provider not in self._PROVIDER_ENV_KEYS:
+            candidates.extend(self._GENERIC_ENV_KEYS)
+        return tuple(dict.fromkeys(candidates))
+
+    def _allows_dummy_key(self) -> bool:
+        provider = self._effective_provider()
+        if provider in self._OPENAI_COMPATIBLE_PROVIDERS:
+            return True
+        model = (self._cfg.model or "").lower()
+        if model.startswith("hosted_vllm/"):
+            return True
+        return self._is_local_api_base()
+
+    def _effective_provider(self) -> str:
+        return (
+            self._custom_llm_provider
+            or self._provider
+            or normalize_provider_name(infer_provider_from_model(self._cfg.model, include_openai_family=True))
+        )
+
+    def _is_local_api_base(self) -> bool:
+        return is_local_api_base(self._cfg.api_base or self._cfg.mock_api_base)
+
+    @staticmethod
+    def _first_present(values: Iterable[str | None]) -> str | None:
+        return next((value for value in values if value), None)
+
+    @staticmethod
+    def _first_env(names: Iterable[str]) -> str | None:
+        return next((os.getenv(name) for name in names if os.getenv(name)), None)

--- a/src/gage_eval/role/model/backends/litellm/errors.py
+++ b/src/gage_eval/role/model/backends/litellm/errors.py
@@ -1,0 +1,56 @@
+"""LiteLLM backend error classification helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+DEPENDENCY_UNAVAILABLE = "dependency_unavailable"
+INVALID_MEDIA_PAYLOAD = "invalid_media_payload"
+INVALID_REQUEST = "invalid_request"
+MEDIA_PAYLOAD_TOO_LARGE = "media_payload_too_large"
+UNSUPPORTED_CAPABILITY = "unsupported_capability"
+
+
+class LiteLLMBackendError(RuntimeError):
+    """Backend error with a stable machine-readable type."""
+
+    def __init__(self, message: str, error_type: str) -> None:
+        self.message = message
+        self.error_type = error_type
+        super().__init__(message)
+
+    def __str__(self) -> str:
+        return f"{self.message} (error_type={self.error_type})"
+
+
+def status_code_from_error(exc: Exception) -> int | None:
+    """Extract an HTTP status code from common LiteLLM/provider exception shapes."""
+
+    for attr in ("status_code", "status"):
+        value = getattr(exc, attr, None)
+        code = _coerce_status(value)
+        if code is not None:
+            return code
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        for attr in ("status_code", "status"):
+            value = getattr(response, attr, None)
+            code = _coerce_status(value)
+            if code is not None:
+                return code
+        if isinstance(response, dict):
+            code = _coerce_status(response.get("status_code") or response.get("status"))
+            if code is not None:
+                return code
+
+    return None
+
+
+def _coerce_status(value: Any) -> int | None:
+    try:
+        code = int(value)
+    except (TypeError, ValueError):
+        return None
+    return code if 100 <= code <= 599 else None

--- a/src/gage_eval/role/model/backends/litellm/message_normalizer.py
+++ b/src/gage_eval/role/model/backends/litellm/message_normalizer.py
@@ -1,0 +1,638 @@
+"""Normalize multimodal chat message blocks for LiteLLM."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Sequence
+
+from gage_eval.role.model.backends.litellm.errors import (
+    INVALID_MEDIA_PAYLOAD,
+    MEDIA_PAYLOAD_TOO_LARGE,
+)
+from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+from gage_eval.role.model.config.litellm import LiteLLMMultimodalPolicyConfig
+
+
+_URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+_BASE64_ALPHABET = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")
+
+
+@dataclass(frozen=True)
+class _DataUrl:
+    mime_type: str
+    payload: str
+    decoded_size: int
+
+
+class MultimodalMessageNormalizer:
+    """Preserve LiteLLM-supported multimodal content blocks without silent drops."""
+
+    _MULTIMODAL_TYPES = frozenset(
+        {
+            "image",
+            "image_url",
+            "input_audio",
+            "audio_url",
+            "video_url",
+            "file",
+            "file_url",
+            "document",
+        }
+    )
+
+    def __init__(
+        self,
+        policy: LiteLLMMultimodalPolicyConfig | Mapping[str, Any] | None = None,
+        *,
+        service_profile: VLLMServiceProfile | None = None,
+    ) -> None:
+        self.policy = self._coerce_policy(policy)
+        self.service_profile = service_profile
+
+    def normalize(
+        self,
+        messages: Sequence[Mapping[str, Any]] | None,
+        *,
+        multimodal: LiteLLMMultimodalPolicyConfig | Mapping[str, Any] | None = None,
+        service_profile: VLLMServiceProfile | None = None,
+        profile: VLLMServiceProfile | None = None,
+        preserve_blocks: bool | None = None,
+        audio_url_mapping: str | None = None,
+        default_audio_format: str | None = None,
+        max_media_bytes: int | None = None,
+        fallback: str | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Return normalized messages suitable for LiteLLM ``completion`` calls."""
+
+        policy = self._resolve_policy(
+            multimodal,
+            preserve_blocks=preserve_blocks,
+            audio_url_mapping=audio_url_mapping,
+            default_audio_format=default_audio_format,
+            max_media_bytes=max_media_bytes,
+            fallback=fallback,
+        )
+        normalized: List[Dict[str, Any]] = []
+        for message in messages or []:
+            new_message = dict(message)
+            content = message.get("content")
+            if isinstance(content, list):
+                new_message["content"] = self._normalize_content_list(content, policy)
+            normalized.append(new_message)
+
+        resolved_profile = service_profile or profile or self.service_profile
+        if self._is_language_model_only(resolved_profile):
+            offending_type = self._first_multimodal_type(normalized)
+            if offending_type:
+                raise ValueError(
+                    f"language_model_only: multimodal content block type={offending_type} is not supported "
+                    "(error_type=unsupported_capability)"
+                )
+        return normalized
+
+    def _normalize_content_list(
+        self,
+        content: Sequence[Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> List[Dict[str, Any]]:
+        normalized: List[Dict[str, Any]] = []
+        for item in content:
+            block = self._normalize_content_item(item, policy)
+            if block is not None:
+                normalized.append(block)
+        return normalized
+
+    def _normalize_content_item(
+        self,
+        item: Any,
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any] | None:
+        if item is None:
+            return None
+        if not isinstance(item, Mapping):
+            return {"type": "text", "text": str(item)}
+
+        block_type = item.get("type")
+        if block_type is None and "text" in item:
+            block_type = "text"
+
+        if block_type == "text":
+            return self._normalize_text(item)
+        if block_type in self._MULTIMODAL_TYPES and policy.preserve_blocks is False:
+            return self._handle_unsupported_block(item, block_type, policy)
+        if block_type == "image_url":
+            return self._normalize_image_url(item, policy)
+        if block_type == "image":
+            return self._normalize_image(item, policy)
+        if block_type == "input_audio":
+            return self._normalize_input_audio(item, policy)
+        if block_type == "audio_url":
+            return self._normalize_audio_url(item, policy)
+        if block_type == "video_url":
+            return self._normalize_video_url(item, policy)
+        if block_type == "file":
+            return self._normalize_file(item, policy)
+        if block_type == "file_url":
+            return self._normalize_file_url(item, policy)
+        if block_type == "document":
+            return self._normalize_document(item, policy)
+        return self._handle_unsupported_block(item, block_type, policy)
+
+    @staticmethod
+    def _normalize_text(item: Mapping[str, Any]) -> Dict[str, str]:
+        return {"type": "text", "text": str(item.get("text", ""))}
+
+    def _normalize_image_url(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        payload = self._url_payload_from_block(item, "image_url", aliases=("image",), policy=policy)
+        return {"type": "image_url", "image_url": payload}
+
+    def _normalize_image(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        payload = self._url_payload_from_block(item, "image", aliases=("image_url",), policy=policy)
+        return {"type": "image_url", "image_url": payload}
+
+    def _normalize_input_audio(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        raw = item.get("input_audio")
+        payload = dict(raw) if isinstance(raw, Mapping) else {}
+        for key in ("data", "url", "format"):
+            if item.get(key) is not None and key not in payload:
+                payload[key] = item[key]
+        if not payload.get("data") and not payload.get("url"):
+            self._raise_invalid("input_audio", "missing data or url")
+        data = payload.get("data")
+        if isinstance(data, str):
+            self._validate_base64_payload(data, "input_audio", policy)
+        url = payload.get("url")
+        if isinstance(url, str) and url.startswith("data:"):
+            self._parse_data_url(url, "input_audio", policy)
+        return {"type": "input_audio", "input_audio": payload}
+
+    def _normalize_audio_url(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        payload = self._url_payload_from_block(item, "audio_url", aliases=("audio",), policy=policy)
+        if policy.audio_url_mapping == "input_audio":
+            url = payload.get("url")
+            if not isinstance(url, str) or not url.startswith("data:"):
+                self._raise_invalid("audio_url", "audio_url_mapping=input_audio requires a data URL")
+            data_url = self._parse_data_url(url, "audio_url", policy)
+            audio_format = self._audio_format_from_mime(data_url.mime_type)
+            audio_format = audio_format or payload.get("format") or policy.default_audio_format
+            if not audio_format:
+                self._raise_invalid("audio_url", "missing audio format")
+            return {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": data_url.payload,
+                    "format": str(audio_format),
+                },
+            }
+        return {"type": "audio_url", "audio_url": payload}
+
+    def _normalize_video_url(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        payload = self._url_payload_from_block(item, "video_url", aliases=("video",), policy=policy)
+        return {"type": "video_url", "video_url": payload}
+
+    def _normalize_file(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        raw = item.get("file")
+        payload = self._file_payload(raw, item, policy)
+        return {"type": "file", "file": payload}
+
+    def _normalize_file_url(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        raw = item.get("file_url")
+        payload = self._file_url_payload(raw, item, policy)
+        return {"type": "file", "file": payload}
+
+    def _normalize_document(
+        self,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        source = item.get("source")
+        if isinstance(source, Mapping):
+            payload: Any = dict(source)
+            self._validate_document_payload(payload, policy)
+            return {"type": "document", "source": payload}
+        if isinstance(source, str):
+            self._validate_document_payload(source, policy)
+            return {"type": "document", "source": source}
+
+        raw = item.get("document")
+        if isinstance(raw, Mapping):
+            payload: Any = dict(raw)
+        elif isinstance(raw, str):
+            payload = raw
+        else:
+            url = item.get("url")
+            if isinstance(url, str):
+                payload = {"url": url}
+            else:
+                self._raise_invalid("document", "missing document source")
+        self._validate_document_payload(payload, policy)
+        return {"type": "document", "document": payload}
+
+    def _url_payload_from_block(
+        self,
+        item: Mapping[str, Any],
+        field_name: str,
+        *,
+        aliases: Sequence[str],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        raw = item.get(field_name)
+        if isinstance(raw, Mapping):
+            payload = dict(raw)
+        elif isinstance(raw, str):
+            payload = {"url": raw}
+        else:
+            payload = {}
+
+        for key in ("url", *aliases):
+            value = item.get(key)
+            if value and "url" not in payload:
+                payload["url"] = value
+        for key in ("detail", "format"):
+            if item.get(key) is not None and key not in payload:
+                payload[key] = item[key]
+
+        url = payload.get("url")
+        if not isinstance(url, str) or not url:
+            self._raise_invalid(str(field_name), "missing url")
+        if url.startswith("data:"):
+            self._parse_data_url(url, str(field_name), policy)
+        return payload
+
+    def _file_payload(
+        self,
+        raw: Any,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        if isinstance(raw, Mapping):
+            payload = dict(raw)
+        elif isinstance(raw, str):
+            payload = self._file_payload_from_string(raw, policy)
+        else:
+            payload = {}
+
+        for key in ("file_id", "file_data", "url", "filename"):
+            if item.get(key) is not None and key not in payload:
+                payload[key] = item[key]
+
+        if not any(payload.get(key) for key in ("file_id", "file_data", "url")):
+            self._raise_invalid("file", "missing file_id, file_data, or url")
+        file_data = payload.get("file_data")
+        if isinstance(file_data, str):
+            if file_data.startswith("data:"):
+                self._parse_data_url(file_data, "file", policy)
+            else:
+                self._validate_base64_payload(file_data, "file", policy)
+        url = payload.get("url")
+        if isinstance(url, str) and url.startswith("data:"):
+            self._parse_data_url(url, "file", policy)
+        return payload
+
+    def _file_url_payload(
+        self,
+        raw: Any,
+        item: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        if isinstance(raw, Mapping):
+            payload = dict(raw)
+            url = payload.pop("url", None)
+            if isinstance(url, str) and url.startswith("data:"):
+                self._parse_data_url(url, "file", policy)
+            if payload.get("file_id") is None and isinstance(url, str):
+                payload["file_id"] = url
+        elif isinstance(raw, str):
+            payload = {"file_id": raw}
+        else:
+            payload = {}
+
+        item_url = item.get("url")
+        if item.get("file_id") is not None and "file_id" not in payload:
+            payload["file_id"] = item["file_id"]
+        if isinstance(item_url, str) and item_url.startswith("data:"):
+            self._parse_data_url(item_url, "file", policy)
+        if item_url is not None and "file_id" not in payload:
+            payload["file_id"] = item_url
+        for key in ("file_data", "filename"):
+            if item.get(key) is not None and key not in payload:
+                payload[key] = item[key]
+
+        if not any(payload.get(key) for key in ("file_id", "file_data")):
+            self._raise_invalid("file", "missing file_id or file_data")
+        file_data = payload.get("file_data")
+        if isinstance(file_data, str):
+            if file_data.startswith("data:"):
+                self._parse_data_url(file_data, "file", policy)
+            else:
+                self._validate_base64_payload(file_data, "file", policy)
+        file_id = payload.get("file_id")
+        if isinstance(file_id, str) and file_id.startswith("data:"):
+            self._parse_data_url(file_id, "file", policy)
+        return payload
+
+    def _file_payload_from_string(self, value: str, policy: LiteLLMMultimodalPolicyConfig) -> Dict[str, Any]:
+        if value.startswith("data:"):
+            self._parse_data_url(value, "file", policy)
+            return {"file_data": value}
+        if _URL_SCHEME_RE.match(value):
+            return {"url": value}
+        return {"file_id": value}
+
+    def _validate_document_payload(
+        self,
+        payload: Any,
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> None:
+        if isinstance(payload, Mapping):
+            self._validate_document_mapping(payload, policy)
+        elif isinstance(payload, str) and payload.startswith("data:"):
+            self._parse_data_url(payload, "document", policy)
+
+    def _validate_document_mapping(
+        self,
+        payload: Mapping[str, Any],
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> None:
+        for key, value in payload.items():
+            if isinstance(value, Mapping):
+                self._validate_document_mapping(value, policy)
+            elif isinstance(value, str) and value.startswith("data:"):
+                self._parse_data_url(value, "document", policy)
+            elif key in {"data", "file_data"} and isinstance(value, str):
+                self._validate_base64_payload(value, "document", policy)
+
+    def _handle_unsupported_block(
+        self,
+        item: Mapping[str, Any],
+        block_type: Any,
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> Dict[str, Any]:
+        if policy.fallback == "preserve":
+            return dict(item)
+        if policy.fallback == "text":
+            text = item.get("text")
+            if text is None:
+                text = f"[unsupported multimodal block: {block_type or 'unknown'}]"
+            return {"type": "text", "text": str(text)}
+        raise ValueError(
+            f"unsupported_modality: type={block_type or 'unknown'} fallback=fail "
+            "(error_type=unsupported_capability)"
+        )
+
+    def _parse_data_url(
+        self,
+        value: str,
+        block_type: str,
+        policy: LiteLLMMultimodalPolicyConfig,
+    ) -> _DataUrl:
+        comma_index = value.find(",")
+        if not value.startswith("data:") or comma_index < len("data:"):
+            self._raise_invalid(block_type, "invalid data URL")
+        mime_type, has_base64 = self._parse_data_url_metadata(value, len("data:"), comma_index)
+        if not has_base64:
+            self._raise_invalid(block_type, "data URL must use base64 payload")
+        payload_start = comma_index + 1
+        decoded_size = self._validate_base64_payload_range(
+            value,
+            payload_start,
+            len(value),
+            block_type,
+            policy,
+            mime_type=mime_type,
+        )
+        payload = value[payload_start:]
+        return _DataUrl(mime_type=mime_type, payload=payload, decoded_size=decoded_size)
+
+    @staticmethod
+    def _parse_data_url_metadata(value: str, start: int, end: int) -> tuple[str, bool]:
+        mime_type = ""
+        has_base64 = False
+        part_start = start
+        part_index = 0
+        index = start
+        while index <= end:
+            if index == end or value[index] == ";":
+                if index > part_start:
+                    if part_index == 0 and value.find("/", part_start, index) != -1:
+                        mime_type = _slice_mime_type(value, part_start, index)
+                    elif _range_equals_ascii_lower(value, part_start, index, "base64"):
+                        has_base64 = True
+                part_index += 1
+                part_start = index + 1
+            index += 1
+        return mime_type, has_base64
+
+    def _validate_base64_payload(
+        self,
+        payload: str,
+        block_type: str,
+        policy: LiteLLMMultimodalPolicyConfig,
+        *,
+        mime_type: str | None = None,
+    ) -> int:
+        return self._validate_base64_payload_range(
+            payload,
+            0,
+            len(payload),
+            block_type,
+            policy,
+            mime_type=mime_type,
+        )
+
+    def _validate_base64_payload_range(
+        self,
+        value: str,
+        start: int,
+        end: int,
+        block_type: str,
+        policy: LiteLLMMultimodalPolicyConfig,
+        *,
+        mime_type: str | None = None,
+    ) -> int:
+        encoded_chars = 0
+        padding = 0
+        padding_started = False
+        limit = policy.max_media_bytes
+
+        for index in range(start, end):
+            char = value[index]
+            if char.isspace():
+                continue
+            if char == "=":
+                padding_started = True
+                padding += 1
+                encoded_chars += 1
+                if padding > 2:
+                    self._raise_invalid(block_type, "invalid base64 padding", mime_type=mime_type)
+            elif char in _BASE64_ALPHABET:
+                if padding_started:
+                    self._raise_invalid(block_type, "invalid base64 padding", mime_type=mime_type)
+                encoded_chars += 1
+            else:
+                self._raise_invalid(block_type, "invalid base64 payload", mime_type=mime_type)
+
+            if limit is not None:
+                decoded_lower_bound = max(0, (encoded_chars // 4) * 3 - 2)
+                if decoded_lower_bound > limit:
+                    raise self._media_payload_too_large(
+                        block_type,
+                        size=decoded_lower_bound,
+                        limit=limit,
+                        mime_type=mime_type,
+                    )
+
+        if encoded_chars == 0 or encoded_chars % 4 != 0:
+            self._raise_invalid(block_type, "invalid base64 payload", mime_type=mime_type)
+
+        decoded_size = (encoded_chars // 4) * 3 - padding
+        if limit is not None and decoded_size > limit:
+            raise self._media_payload_too_large(
+                block_type,
+                size=decoded_size,
+                limit=limit,
+                mime_type=mime_type,
+            )
+        return decoded_size
+
+    @staticmethod
+    def _audio_format_from_mime(mime_type: str) -> str | None:
+        if not mime_type.startswith("audio/"):
+            return None
+        subtype = mime_type.split("/", 1)[1].strip()
+        return subtype or None
+
+    @staticmethod
+    def _is_language_model_only(profile: VLLMServiceProfile | None) -> bool:
+        if profile is None:
+            return False
+        if profile.language_model_only is True:
+            return True
+        topology = profile.topology
+        return isinstance(topology, Mapping) and topology.get("language_model_only") is True
+
+    @classmethod
+    def _first_multimodal_type(cls, messages: Sequence[Mapping[str, Any]]) -> str | None:
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if isinstance(item, Mapping) and item.get("type") in cls._MULTIMODAL_TYPES:
+                    return str(item.get("type"))
+        return None
+
+    @staticmethod
+    def _coerce_policy(
+        policy: LiteLLMMultimodalPolicyConfig | Mapping[str, Any] | None,
+    ) -> LiteLLMMultimodalPolicyConfig:
+        if policy is None:
+            return LiteLLMMultimodalPolicyConfig()
+        if isinstance(policy, LiteLLMMultimodalPolicyConfig):
+            return policy
+        return LiteLLMMultimodalPolicyConfig(**dict(policy))
+
+    def _resolve_policy(
+        self,
+        policy: LiteLLMMultimodalPolicyConfig | Mapping[str, Any] | None,
+        *,
+        preserve_blocks: bool | None,
+        audio_url_mapping: str | None,
+        default_audio_format: str | None,
+        max_media_bytes: int | None,
+        fallback: str | None,
+    ) -> LiteLLMMultimodalPolicyConfig:
+        resolved = self._coerce_policy(policy) if policy is not None else self.policy
+        overrides: Dict[str, Any] = {}
+        if preserve_blocks is not None:
+            overrides["preserve_blocks"] = preserve_blocks
+        if audio_url_mapping is not None:
+            overrides["audio_url_mapping"] = audio_url_mapping
+        if default_audio_format is not None:
+            overrides["default_audio_format"] = default_audio_format
+        if max_media_bytes is not None:
+            overrides["max_media_bytes"] = max_media_bytes
+        if fallback is not None:
+            overrides["fallback"] = fallback
+        if not overrides:
+            return resolved
+        if hasattr(resolved, "model_dump"):
+            data = resolved.model_dump()
+        else:  # pragma: no cover - pydantic v1 fallback
+            data = resolved.dict()
+        data.update(overrides)
+        return LiteLLMMultimodalPolicyConfig(**data)
+
+    @staticmethod
+    def _raise_invalid(block_type: str, reason: str, *, mime_type: str | None = None) -> None:
+        mime = f" mime={_safe_diag_value(mime_type)}" if mime_type else ""
+        raise ValueError(
+            f"{INVALID_MEDIA_PAYLOAD}: type={block_type} reason={reason}{mime} "
+            f"(error_type={INVALID_MEDIA_PAYLOAD})"
+        )
+
+    @staticmethod
+    def _media_payload_too_large(
+        block_type: str,
+        *,
+        size: int,
+        limit: int,
+        mime_type: str | None,
+    ) -> ValueError:
+        mime = f" mime={_safe_diag_value(mime_type)}" if mime_type else ""
+        return ValueError(
+            f"{MEDIA_PAYLOAD_TOO_LARGE}: type={block_type} size={size} limit={limit}{mime} "
+            f"(error_type={MEDIA_PAYLOAD_TOO_LARGE})"
+        )
+
+
+def _safe_diag_value(value: Any, limit: int = 64) -> str:
+    text = str(value)
+    safe = "".join(char if 32 <= ord(char) < 127 else "?" for char in text[:limit])
+    if len(text) <= limit:
+        return safe
+    return f"{safe}...(len={len(text)})"
+
+
+def _slice_mime_type(value: str, start: int, end: int, limit: int = 128) -> str:
+    if end - start > limit:
+        return ""
+    return value[start:end]
+
+
+def _range_equals_ascii_lower(value: str, start: int, end: int, expected: str) -> bool:
+    if end - start != len(expected):
+        return False
+    for offset, expected_char in enumerate(expected):
+        if value[start + offset].lower() != expected_char:
+            return False
+    return True

--- a/src/gage_eval/role/model/backends/litellm/model_server_lifecycle.py
+++ b/src/gage_eval/role/model/backends/litellm/model_server_lifecycle.py
@@ -1,0 +1,192 @@
+"""Experimental local model server lifecycle support for LiteLLM backends."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.request import Request, urlopen as default_urlopen
+
+from gage_eval.role.model.backends.litellm.errors import DEPENDENCY_UNAVAILABLE, LiteLLMBackendError
+
+
+@dataclass(frozen=True)
+class ModelServerState:
+    """Result of a model server readiness check."""
+
+    enabled: bool
+    ready: bool
+    started: bool
+    health_urls: tuple[str, ...] = ()
+
+
+class ModelServerLifecycle:
+    """Start a user-provided local model server command and wait for health."""
+
+    _MIN_HEALTH_INTERVAL_SECONDS = 0.1
+    _UNTRUSTED_PATTERNS = (
+        re.compile(r"\bcurl\b.+\|\s*(?:bash|sh)\b", re.IGNORECASE | re.DOTALL),
+        re.compile(r"\bwget\b.+\|\s*(?:bash|sh)\b", re.IGNORECASE | re.DOTALL),
+        re.compile(r"\brm\s+-[^\n;|&]*[rf][^\n;|&]*\s+/", re.IGNORECASE),
+        re.compile(r"\bmkfs(?:\.[A-Za-z0-9_+-]+)?\b", re.IGNORECASE),
+    )
+
+    def __init__(
+        self,
+        *,
+        popen: Callable[..., Any] = subprocess.Popen,
+        urlopen: Callable[..., Any] = default_urlopen,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._popen = popen
+        self._urlopen = urlopen
+        self._sleep = sleep
+        self._monotonic = monotonic
+        self._started_processes: dict[tuple[str, tuple[str, ...]], Any] = {}
+
+    def ensure_ready(self, config: Any) -> ModelServerState:
+        """Ensure the configured experimental model server is ready."""
+
+        if not self._enabled(config):
+            return ModelServerState(enabled=False, ready=True, started=False)
+
+        startup_command = self._validate_trusted_command(self._get(config, "startup_command"))
+        urls = self._health_urls(config)
+        if not urls:
+            raise ValueError("model_server.health.urls must contain at least one health URL when enabled.")
+
+        if self._are_healthy(urls):
+            return ModelServerState(enabled=True, ready=True, started=False, health_urls=tuple(urls))
+
+        key = (startup_command, tuple(urls))
+        process = self._started_processes.get(key)
+        started = False
+        if process is None:
+            process = self._start_command(startup_command)
+            self._started_processes[key] = process
+            started = True
+        timeout_seconds = self._health_timeout_seconds(config)
+        interval_seconds = self._health_interval_seconds(config)
+        self._wait_until_healthy(
+            urls,
+            timeout_seconds=timeout_seconds,
+            interval_seconds=interval_seconds,
+            process=process,
+            startup_command=startup_command,
+        )
+        return ModelServerState(enabled=True, ready=True, started=started, health_urls=tuple(urls))
+
+    def _wait_until_healthy(
+        self,
+        urls: list[str],
+        *,
+        timeout_seconds: float,
+        interval_seconds: float,
+        process: Any | None,
+        startup_command: str,
+    ) -> None:
+        deadline = self._monotonic() + timeout_seconds
+        while True:
+            if self._are_healthy(urls):
+                return
+            self._raise_if_process_exited(process, startup_command)
+            now = self._monotonic()
+            if now >= deadline:
+                raise LiteLLMBackendError(
+                    "Model server health check timed out before all URLs became healthy: "
+                    + ", ".join(urls),
+                    DEPENDENCY_UNAVAILABLE,
+                )
+            self._sleep(min(interval_seconds, max(0.0, deadline - now)))
+
+    def _are_healthy(self, urls: list[str]) -> bool:
+        return all(self._is_healthy(url) for url in urls)
+
+    def _is_healthy(self, url: str) -> bool:
+        request = Request(url, method="GET")
+        try:
+            with self._urlopen(request, timeout=2.0) as response:
+                status = getattr(response, "status", None) or getattr(response, "code", None) or 200
+                if int(status) >= 400:
+                    return False
+                read = getattr(response, "read", None)
+                if callable(read):
+                    read()
+                return True
+        except Exception:
+            return False
+
+    def _start_command(self, startup_command: str) -> Any:
+        try:
+            return self._popen(["bash", "-lc", startup_command], stdin=subprocess.DEVNULL)
+        except Exception as exc:
+            raise LiteLLMBackendError(
+                f"Model server startup command failed: {exc}",
+                DEPENDENCY_UNAVAILABLE,
+            ) from exc
+
+    def _raise_if_process_exited(self, process: Any | None, startup_command: str) -> None:
+        if process is None:
+            return
+        poll = getattr(process, "poll", None)
+        if not callable(poll):
+            return
+        returncode = poll()
+        if returncode not in (None, 0):
+            raise LiteLLMBackendError(
+                f"Model server startup command exited with code {returncode}: {startup_command}",
+                DEPENDENCY_UNAVAILABLE,
+            )
+
+    def _validate_trusted_command(self, startup_command: Any) -> str:
+        if not isinstance(startup_command, str):
+            raise ValueError("model_server.startup_command must be a string.")
+        command = startup_command.strip()
+        if not command:
+            raise ValueError("model_server.startup_command must not be empty.")
+        if "\x00" in command:
+            raise ValueError("model_server.startup_command must not contain NUL bytes.")
+        if any(pattern.search(command) for pattern in self._UNTRUSTED_PATTERNS):
+            raise ValueError("model_server.startup_command contains obviously unsafe shell input.")
+        return startup_command
+
+    @staticmethod
+    def _enabled(config: Any) -> bool:
+        return bool(ModelServerLifecycle._get(config, "enabled", False))
+
+    @staticmethod
+    def _get(config: Any, key: str, default: Any = None) -> Any:
+        if isinstance(config, dict):
+            return config.get(key, default)
+        return getattr(config, key, default)
+
+    def _health_urls(self, config: Any) -> list[str]:
+        health = self._get(config, "health")
+        urls = self._get(health, "urls", []) if health is not None else []
+        if urls is None:
+            return []
+        if not isinstance(urls, list):
+            raise ValueError("model_server.health.urls must be a list of URLs.")
+        validated: list[str] = []
+        for url in urls:
+            if not isinstance(url, str) or not url.strip():
+                raise ValueError("model_server.health.urls must only contain non-empty strings.")
+            validated.append(url.strip())
+        return validated
+
+    def _health_timeout_seconds(self, config: Any) -> float:
+        health = self._get(config, "health")
+        value = self._get(health, "timeout_seconds", None) if health is not None else None
+        if value is None:
+            return 300.0
+        return float(value)
+
+    def _health_interval_seconds(self, config: Any) -> float:
+        health = self._get(config, "health")
+        value = self._get(health, "interval_seconds", None) if health is not None else None
+        if value is None:
+            return 2.0
+        return max(self._MIN_HEALTH_INTERVAL_SECONDS, float(value))

--- a/src/gage_eval/role/model/backends/litellm/policies.py
+++ b/src/gage_eval/role/model/backends/litellm/policies.py
@@ -1,0 +1,525 @@
+"""LiteLLM request policies."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Literal
+from urllib.parse import urlsplit
+
+from loguru import logger
+
+from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+
+ThinkingMode = Literal["enabled", "disabled", "auto", "unknown"]
+ThinkingCapability = Literal["auto", "supported", "unsupported"]
+UnsupportedAction = Literal["warn_and_continue", "fail_fast", "ignore"]
+
+
+@dataclass(frozen=True)
+class ThinkingResolution:
+    """Resolved thinking request policy."""
+
+    mode: ThinkingMode
+    kwargs_patch: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class ThinkingControlPolicy:
+    """Map GAGE thinking controls to provider-specific LiteLLM kwargs."""
+
+    def __init__(
+        self,
+        *,
+        service_profile: VLLMServiceProfile | None = None,
+        capability: Any | None = None,
+        on_unsupported: UnsupportedAction | None = None,
+        on_mismatch: UnsupportedAction | None = None,
+        record_effective_state: bool | None = None,
+    ) -> None:
+        self.service_profile = service_profile
+        self.capability = self._normalize_capability(capability)
+        self.on_unsupported: UnsupportedAction = on_unsupported or "warn_and_continue"
+        # Reserved for the response-normalization phase: request building only
+        # resolves outbound kwargs and does not compare returned effective state.
+        self.on_mismatch: UnsupportedAction = on_mismatch or "warn_and_continue"
+        self.record_effective_state = bool(record_effective_state)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Any,
+        *,
+        service_profile: VLLMServiceProfile | None = None,
+    ) -> "ThinkingControlPolicy":
+        """Build a policy from the optional LiteLLM thinking policy config."""
+
+        if config is None:
+            return cls(service_profile=service_profile)
+        get = config.get if isinstance(config, dict) else lambda key, default=None: getattr(config, key, default)
+        return cls(
+            service_profile=service_profile,
+            capability=get("capability"),
+            on_unsupported=get("on_unsupported"),
+            on_mismatch=get("on_mismatch"),
+            record_effective_state=get("record_effective_state", None),
+        )
+
+    def resolve(
+        self,
+        *,
+        model: str,
+        provider: str | None = None,
+        custom_llm_provider: str | None = None,
+        api_base: str | None = None,
+        thinking_config: Dict[str, Any] | None = None,
+    ) -> ThinkingResolution:
+        """Resolve thinking mode into LiteLLM kwargs and request metadata."""
+
+        thinking_config = dict(thinking_config or {})
+        mode = self._resolve_mode(thinking_config)
+        include_profile_parser_target = self.capability != "supported"
+        is_vllm_target = self._is_vllm_openai_compatible_target(
+            model=model,
+            provider=provider,
+            custom_llm_provider=custom_llm_provider,
+            api_base=api_base,
+            include_profile_parser=include_profile_parser_target,
+        )
+        metadata: Dict[str, Any] = {
+            "thinking_mode": mode,
+            "thinking_capability": self.capability,
+            "thinking_target": "vllm_openai_compatible" if is_vllm_target else "generic",
+        }
+        if self.service_profile and self.service_profile.reasoning_parser:
+            metadata["reasoning_parser"] = self.service_profile.reasoning_parser
+
+        kwargs_patch: Dict[str, Any] = {}
+        reasoning_effort = thinking_config.get("reasoning_effort")
+
+        if mode == "enabled" and self.capability == "unsupported":
+            self._handle_unsupported_enabled_capability(model)
+            if reasoning_effort:
+                kwargs_patch["reasoning_effort"] = reasoning_effort
+            return ThinkingResolution(mode=mode, kwargs_patch=kwargs_patch, metadata=metadata)
+
+        if (
+            mode == "enabled"
+            and self.capability == "auto"
+            and is_vllm_target
+            and not metadata.get("reasoning_parser")
+        ):
+            self._handle_unsupported_enabled_vllm_target(model)
+
+        if mode in {"enabled", "disabled"} and is_vllm_target:
+            kwargs_patch = {
+                "extra_body": {
+                    "chat_template_kwargs": {
+                        "enable_thinking": mode == "enabled",
+                    }
+                }
+            }
+
+        if reasoning_effort:
+            kwargs_patch["reasoning_effort"] = reasoning_effort
+
+        return ThinkingResolution(mode=mode, kwargs_patch=kwargs_patch, metadata=metadata)
+
+    @staticmethod
+    def _normalize_capability(capability: Any | None) -> ThinkingCapability:
+        if capability is None:
+            return "auto"
+        if capability is True:
+            return "supported"
+        if capability is False:
+            return "unsupported"
+        normalized = str(capability).strip().lower().replace("-", "_")
+        aliases = {
+            "": "auto",
+            "auto": "auto",
+            "automatic": "auto",
+            "default": "auto",
+            "none": "auto",
+            "supported": "supported",
+            "support": "supported",
+            "supports": "supported",
+            "true": "supported",
+            "yes": "supported",
+            "enabled": "supported",
+            "unsupported": "unsupported",
+            "not_supported": "unsupported",
+            "false": "unsupported",
+            "no": "unsupported",
+            "disabled": "unsupported",
+        }
+        return aliases.get(normalized, "auto")
+
+    @staticmethod
+    def _resolve_mode(thinking_config: Dict[str, Any]) -> ThinkingMode:
+        raw_mode = thinking_config.get("thinking_mode")
+        chat_template_kwargs = thinking_config.get("chat_template_kwargs")
+        if raw_mode is None and isinstance(chat_template_kwargs, dict) and "enable_thinking" in chat_template_kwargs:
+            enable_thinking = chat_template_kwargs.get("enable_thinking")
+            if enable_thinking is True:
+                return "enabled"
+            if enable_thinking is False:
+                return "disabled"
+        if raw_mode is None and "enable_thinking" in thinking_config:
+            enable_thinking = thinking_config.get("enable_thinking")
+            if enable_thinking is True:
+                return "enabled"
+            if enable_thinking is False:
+                return "disabled"
+        if raw_mode is None:
+            return "auto"
+        normalized = str(raw_mode).strip().lower()
+        if normalized in {"enabled", "enable", "true", "on"}:
+            return "enabled"
+        if normalized in {"disabled", "disable", "false", "off"}:
+            return "disabled"
+        if normalized in {"auto", "default", "none", ""}:
+            return "auto"
+        return "unknown"
+
+    def _is_vllm_openai_compatible_target(
+        self,
+        *,
+        model: str,
+        provider: str | None,
+        custom_llm_provider: str | None,
+        api_base: str | None,
+        include_profile_parser: bool = True,
+    ) -> bool:
+        model_lower = (model or "").lower()
+        providers = {
+            (provider or "").lower().replace("-", "_"),
+            (custom_llm_provider or "").lower().replace("-", "_"),
+        }
+        official_openai_providers = {"openai", "azure", "azure_openai"}
+        if model_lower.startswith("hosted_vllm/"):
+            return True
+        if providers & {"hosted_vllm", "vllm", "openai_compatible"}:
+            return True
+        if self._is_official_openai_or_azure_endpoint(api_base):
+            return False
+        if not (api_base or "").strip() and providers & official_openai_providers:
+            return False
+        if include_profile_parser and self.service_profile and self.service_profile.reasoning_parser:
+            return True
+        return False
+
+    @staticmethod
+    def _is_official_openai_or_azure_endpoint(api_base: str | None) -> bool:
+        if not api_base:
+            return False
+        parsed = urlsplit(api_base)
+        if not parsed.netloc:
+            parsed = urlsplit(f"//{api_base}")
+        host = (parsed.hostname or "").lower().rstrip(".")
+        path = (parsed.path or "").lower()
+        if host == "api.openai.com":
+            return True
+        if host.endswith(".openai.azure.com"):
+            return True
+        if host.endswith(".azure.com") and ("openai" in host or path.startswith("/openai")):
+            return True
+        return False
+
+    def _handle_unsupported_enabled_capability(self, model: str) -> None:
+        message = (
+            f"thinking enabled for model {model!r}, but thinking capability is unsupported "
+            "(error_type=unsupported_capability)"
+        )
+        if self.on_unsupported == "fail_fast":
+            raise ValueError(message)
+        if self.on_unsupported == "warn_and_continue":
+            logger.warning(message)
+
+    def _handle_unsupported_enabled_vllm_target(self, model: str) -> None:
+        message = (
+            f"thinking enabled for vLLM/OpenAI-compatible model {model!r}, "
+            "but vllm.reasoning_parser is not configured (error_type=unsupported_capability)"
+        )
+        if self.on_unsupported == "fail_fast":
+            raise ValueError(message)
+        if self.on_unsupported == "warn_and_continue":
+            logger.warning(message)
+
+
+class ToolCallPolicy:
+    """Format tool-call requests and normalize tool-call responses."""
+
+    def __init__(self, config: Any | None = None, *, supports_function_calling: bool | None = None) -> None:
+        self.config = config
+        self.supports_function_calling = supports_function_calling
+        self.enabled = bool(self._get_config_value("enabled", False))
+        self.tool_choice = self._get_config_value("tool_choice")
+        self.parallel_tool_calls = self._get_config_value("parallel_tool_calls")
+        self.auto_tool_choice = bool(self._get_config_value("auto_tool_choice", False))
+        self.require_server_parser = bool(self._get_config_value("require_server_parser", False))
+        self.expected_server_flags = self._get_config_value("expected_server_flags") or {}
+        self.expected_tool_parser = self._expected_server_flag("tool_call_parser") or self._get_config_value(
+            "expected_tool_parser"
+        )
+
+    @classmethod
+    def from_config(cls, config: Any | None) -> "ToolCallPolicy":
+        """Builds a policy from optional LiteLLM tool-calling config."""
+
+        return cls(config)
+
+    def apply(
+        self,
+        kwargs: Dict[str, Any],
+        inputs: Dict[str, Any],
+        *,
+        supports_function_calling: bool | None = None,
+        is_vllm_tool_target: bool = False,
+    ) -> None:
+        """Applies tool-call kwargs to a LiteLLM request payload.
+
+        Args:
+            kwargs: Mutable LiteLLM kwargs under construction.
+            inputs: Normalized backend inputs containing optional tools.
+
+        Raises:
+            ValueError: If tools are requested but required vLLM parser metadata
+                is missing from the backend configuration.
+        """
+
+        formatted_tools = self.format_tools(inputs.get("tools"))
+        if not formatted_tools:
+            return
+
+        tool_choice = self._resolve_tool_choice(inputs)
+        parallel_tool_calls = self._resolve_parallel_tool_calls(inputs)
+        auto_tools = self._is_auto_tool_choice(tool_choice)
+        require_auto_server_flags = auto_tools and (
+            is_vllm_tool_target or self.require_server_parser or self.auto_tool_choice
+        )
+        self._validate_server_parser(auto_tools=require_auto_server_flags)
+        self._validate_function_calling_support(
+            supports_function_calling,
+            is_vllm_tool_target=is_vllm_tool_target,
+        )
+        kwargs["tools"] = formatted_tools
+
+        if tool_choice is not None:
+            kwargs["tool_choice"] = tool_choice
+
+        if parallel_tool_calls is not None:
+            kwargs["parallel_tool_calls"] = parallel_tool_calls
+
+    def format_tools(self, tools: Any) -> list[Dict[str, Any]]:
+        """Formats simplified and OpenAI tool schemas for LiteLLM."""
+
+        if not tools:
+            return []
+        if isinstance(tools, dict):
+            tools = [tools]
+        if not isinstance(tools, list):
+            return []
+
+        formatted: list[Dict[str, Any]] = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+                formatted.append(
+                    {
+                        "type": "function",
+                        "function": self._format_function_schema(tool["function"]),
+                    }
+                )
+                continue
+            if "name" in tool and "parameters" in tool:
+                formatted.append(
+                    {
+                        "type": "function",
+                        "function": self._format_function_schema(tool),
+                    }
+                )
+                continue
+            formatted.append(copy.deepcopy(tool))
+        return formatted
+
+    @classmethod
+    def normalize_tool_calls(cls, tool_calls: Any) -> list[Dict[str, Any]]:
+        """Normalizes LiteLLM/OpenAI tool calls into GAGE result shape."""
+
+        if not tool_calls:
+            return []
+        if isinstance(tool_calls, dict):
+            tool_calls = [tool_calls]
+        if not isinstance(tool_calls, list):
+            return []
+
+        normalized: list[Dict[str, Any]] = []
+        for tool_call in tool_calls:
+            function = cls._field(tool_call, "function") or {}
+            raw_arguments = cls._field(function, "arguments")
+            if raw_arguments is None:
+                raw_arguments = cls._field(tool_call, "arguments")
+            arguments, raw_arguments_text, error = cls._parse_arguments(raw_arguments)
+
+            item: Dict[str, Any] = {
+                "id": cls._field(tool_call, "id"),
+                "type": cls._field(tool_call, "type") or "function",
+                "name": cls._field(function, "name") or cls._field(tool_call, "name"),
+                "arguments": arguments,
+                "raw_arguments": raw_arguments_text,
+            }
+            if error:
+                item["error"] = error
+            normalized.append(item)
+        return normalized
+
+    @classmethod
+    def merge_tool_call_delta(cls, state: Dict[Any, Dict[str, Any]], tool_call_delta: Any) -> None:
+        """Merges one streaming tool-call delta into mutable aggregation state."""
+
+        index = cls._field(tool_call_delta, "index")
+        tool_call_id = cls._field(tool_call_delta, "id")
+        key = index if index is not None else tool_call_id
+        if key is None:
+            key = len(state)
+
+        entry = state.setdefault(
+            key,
+            {
+                "id": None,
+                "type": "function",
+                "function": {"name": "", "arguments": ""},
+            },
+        )
+        if tool_call_id is not None:
+            entry["id"] = tool_call_id
+        tool_type = cls._field(tool_call_delta, "type")
+        if tool_type is not None:
+            entry["type"] = tool_type
+
+        function_delta = cls._field(tool_call_delta, "function") or {}
+        function_state = entry.setdefault("function", {"name": "", "arguments": ""})
+        name_delta = cls._field(function_delta, "name")
+        if name_delta is not None:
+            function_state["name"] = f"{function_state.get('name') or ''}{name_delta}"
+        arguments_delta = cls._field(function_delta, "arguments")
+        if arguments_delta is not None:
+            function_state["arguments"] = f"{function_state.get('arguments') or ''}{arguments_delta}"
+
+    def _validate_function_calling_support(
+        self,
+        supports_function_calling: bool | None,
+        *,
+        is_vllm_tool_target: bool,
+    ) -> None:
+        resolved_support = self.supports_function_calling if supports_function_calling is None else supports_function_calling
+        if resolved_support is False:
+            if is_vllm_tool_target and self.has_declared_vllm_tool_support():
+                return
+            raise ValueError(
+                "tool_calling_not_supported: model/provider does not support function calling "
+                "(error_type=unsupported_capability)"
+            )
+
+    def _validate_server_parser(self, *, auto_tools: bool) -> None:
+        if self.require_server_parser and not self.expected_tool_parser:
+            raise ValueError(
+                "tool_parser_missing: tool_calling.require_server_parser=true requires "
+                "tool_calling.expected_server_flags.tool_call_parser or tool_calling.expected_tool_parser"
+            )
+        if auto_tools:
+            if self._expected_server_flag("enable_auto_tool_choice") is not True:
+                raise ValueError(
+                    "tool_parser_missing: auto tool choice requires "
+                    "tool_calling.expected_server_flags.enable_auto_tool_choice=true"
+                )
+            if not self.expected_tool_parser:
+                raise ValueError(
+                    "tool_parser_missing: auto tool choice requires "
+                    "tool_calling.expected_server_flags.tool_call_parser or tool_calling.expected_tool_parser"
+                )
+
+    def _get_config_value(self, key: str, default: Any = None) -> Any:
+        if self.config is None:
+            return default
+        if isinstance(self.config, dict):
+            return self.config.get(key, default)
+        return getattr(self.config, key, default)
+
+    def _expected_server_flag(self, key: str, default: Any = None) -> Any:
+        flags = self.expected_server_flags
+        if isinstance(flags, dict):
+            return flags.get(key, default)
+        return getattr(flags, key, default)
+
+    def has_declared_vllm_tool_support(self) -> bool:
+        """Returns whether config declares vLLM tool parser/server flags."""
+
+        return bool(self.expected_tool_parser) or self._expected_server_flag("enable_auto_tool_choice") is not None
+
+    def _resolve_tool_choice(self, inputs: Dict[str, Any]) -> Any:
+        if inputs.get("tool_choice") is not None:
+            return inputs["tool_choice"]
+        if self.tool_choice is not None:
+            return copy.deepcopy(self.tool_choice)
+        if self.auto_tool_choice:
+            return "auto"
+        return None
+
+    def _resolve_parallel_tool_calls(self, inputs: Dict[str, Any]) -> Any:
+        if inputs.get("parallel_tool_calls") is not None:
+            return inputs["parallel_tool_calls"]
+        return self.parallel_tool_calls
+
+    @staticmethod
+    def _is_auto_tool_choice(tool_choice: Any) -> bool:
+        return isinstance(tool_choice, str) and tool_choice.strip().lower() == "auto"
+
+    @staticmethod
+    def _format_function_schema(function_schema: Dict[str, Any]) -> Dict[str, Any]:
+        formatted = copy.deepcopy(function_schema)
+        formatted["name"] = formatted.get("name")
+        formatted["description"] = formatted.get("description", "")
+        formatted["parameters"] = formatted.get("parameters") or {"type": "object", "properties": {}}
+        return formatted
+
+    @classmethod
+    def _parse_arguments(cls, raw_arguments: Any) -> tuple[Any, str, str | None]:
+        if raw_arguments is None:
+            return {}, "", None
+        if isinstance(raw_arguments, str):
+            if raw_arguments.strip() == "":
+                return {}, raw_arguments, None
+            try:
+                return json.loads(raw_arguments), raw_arguments, None
+            except json.JSONDecodeError:
+                return None, raw_arguments, "invalid_tool_arguments"
+
+        jsonable = cls._to_jsonable(raw_arguments)
+        try:
+            raw_arguments_text = json.dumps(jsonable, ensure_ascii=True)
+        except TypeError:
+            raw_arguments_text = str(jsonable)
+        return jsonable, raw_arguments_text, None
+
+    @staticmethod
+    def _field(obj: Any, name: str, default: Any = None) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(name, default)
+        return getattr(obj, name, default)
+
+    @classmethod
+    def _to_jsonable(cls, obj: Any) -> Any:
+        if obj is None or isinstance(obj, (str, int, float, bool)):
+            return obj
+        if isinstance(obj, dict):
+            return {key: cls._to_jsonable(value) for key, value in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [cls._to_jsonable(value) for value in obj]
+        if hasattr(obj, "model_dump"):
+            return cls._to_jsonable(obj.model_dump())
+        if hasattr(obj, "__dict__"):
+            return {key: cls._to_jsonable(value) for key, value in vars(obj).items() if not key.startswith("_")}
+        return str(obj)

--- a/src/gage_eval/role/model/backends/litellm/provider_detection.py
+++ b/src/gage_eval/role/model/backends/litellm/provider_detection.py
@@ -1,0 +1,122 @@
+"""Provider detection helpers for LiteLLM-compatible backends."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+
+LOCAL_API_HOSTS = frozenset({"127.0.0.1", "localhost", "0.0.0.0", "::1"})
+LITELLM_GATEWAY_PROFILES = frozenset(
+    {
+        "external_gateway",
+        "external_litellm_gateway",
+        "gateway",
+        "litellm",
+        "litellm_gateway",
+        "proxy",
+    }
+)
+
+
+def normalize_provider_name(value: str | None) -> str:
+    return (value or "").strip().lower().replace("-", "_")
+
+
+def normalize_custom_provider(provider: str | None) -> str | None:
+    if not provider:
+        return None
+    lower = provider.lower()
+    alias_map = {
+        "deepseek": "deepseek",
+        "kimi": "moonshot",
+        "moonshot": "moonshot",
+        "grok": "xai",
+        "xai": "xai",
+        "google": "gemini",
+        "gemini": "gemini",
+        "azure_openai": "azure",
+        "google_genai": "google",
+    }
+    return alias_map.get(lower, lower)
+
+
+def infer_provider_from_model(
+    model: str | None,
+    *,
+    include_openai_family: bool = False,
+) -> str | None:
+    if not model:
+        return None
+    if "/" in model:
+        return model.split("/", 1)[0]
+    lower = model.lower()
+    if lower.startswith("deepseek"):
+        return "deepseek"
+    if lower.startswith("grok"):
+        return "grok"
+    if lower.startswith("moonshot"):
+        return "kimi"
+    if lower.startswith("azure:"):
+        return "azure"
+    if include_openai_family and lower.startswith(("gpt-", "o1", "o3", "o4")):
+        return "openai"
+    return None
+
+
+def looks_like_deepseek(provider: str | None, model: str, api_base: str | None = None) -> bool:
+    target = (provider or "").lower()
+    model_lower = (model or "").lower()
+    base = (api_base or "").lower()
+    return target == "deepseek" or model_lower.startswith("deepseek") or "deepseek.com" in base
+
+
+def looks_like_kimi(provider: str | None, model: str, api_base: str | None = None) -> bool:
+    target = (provider or "").lower()
+    model_lower = (model or "").lower()
+    base = (api_base or "").lower()
+    return target in {"kimi", "moonshot"} or model_lower.startswith("moonshot") or "moonshot" in base or "kimi" in base
+
+
+def looks_like_grok(provider: str | None, model: str, api_base: str | None = None) -> bool:
+    target = (provider or "").lower()
+    model_lower = (model or "").lower()
+    base = (api_base or "").lower()
+    return target in {"grok", "xai"} or model_lower.startswith("grok") or "api.x.ai" in base or base.endswith("x.ai")
+
+
+def looks_like_azure(provider: str | None, model: str, api_base: str | None = None) -> bool:
+    target = (provider or "").lower()
+    model_lower = (model or "").lower()
+    base = (api_base or "").lower()
+    return target in {"azure", "azure_openai"} or "openai.azure.com" in base or "azure" in base or model_lower.startswith("azure:")
+
+
+def is_explicit_litellm_gateway(
+    provider: str | None = None,
+    *,
+    custom_llm_provider: str | None = None,
+    topology_kind: str | None = None,
+) -> bool:
+    """Return whether config explicitly declares an external LiteLLM Gateway."""
+
+    return any(
+        normalize_provider_name(value) in LITELLM_GATEWAY_PROFILES
+        for value in (provider, custom_llm_provider, topology_kind)
+    )
+
+
+def is_default_local_litellm_gateway(api_base: str | None) -> bool:
+    """Return whether ``api_base`` matches LiteLLM Gateway's common local endpoint."""
+
+    if not api_base:
+        return False
+    parsed = urlsplit(api_base)
+    host = (parsed.hostname or "").lower()
+    return host in LOCAL_API_HOSTS and parsed.port == 4000
+
+
+def is_local_api_base(api_base: str | None) -> bool:
+    if not api_base:
+        return False
+    host = (urlsplit(api_base).hostname or "").lower()
+    return host in LOCAL_API_HOSTS

--- a/src/gage_eval/role/model/backends/litellm/request_builder.py
+++ b/src/gage_eval/role/model/backends/litellm/request_builder.py
@@ -1,0 +1,364 @@
+"""Build LiteLLM completion request kwargs."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
+
+from loguru import logger
+
+from gage_eval.role.model.backends.litellm.errors import INVALID_REQUEST
+from gage_eval.role.model.backends.litellm.policies import (
+    ThinkingControlPolicy,
+    ThinkingResolution,
+    ToolCallPolicy,
+)
+from gage_eval.role.model.backends.litellm.provider_detection import (
+    looks_like_deepseek,
+    normalize_custom_provider,
+)
+from gage_eval.role.model.config.litellm import LiteLLMRequestConfig
+
+LITELLM_REQUEST_PASSTHROUGH_FIELDS: Tuple[str, ...] = (
+    "response_format",
+    "max_completion_tokens",
+    "stream_options",
+    "parallel_tool_calls",
+    "logit_bias",
+    "user",
+    "metadata",
+    "fallbacks",
+    "context_window_fallback_dict",
+    "extra_body",
+    "drop_params",
+)
+
+
+class LiteLLMRequestBuilder:
+    """Build kwargs for ``litellm.completion`` without invoking LiteLLM."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        provider: str | None = None,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        timeout: float | None = None,
+        headers: Dict[str, str] | None = None,
+        custom_llm_provider: str | None = None,
+        base_sampling: Dict[str, Any] | None = None,
+        litellm_request: LiteLLMRequestConfig | None = None,
+        drop_params: bool = True,
+        is_azure_target: bool = False,
+        azure_api_version: str | None = None,
+        max_context_length: int | None = None,
+        supports_reasoning: bool = False,
+        supports_function_calling: bool | None = None,
+        thinking_policy: ThinkingControlPolicy | None = None,
+        tool_call_policy: ToolCallPolicy | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self.provider = provider
+        self.api_base = api_base
+        self.api_key = api_key
+        self.timeout = timeout
+        self.headers = dict(headers or {})
+        self.custom_llm_provider = custom_llm_provider
+        self.base_sampling = copy.deepcopy(base_sampling or {})
+        self.litellm_request = litellm_request or LiteLLMRequestConfig()
+        self.drop_params = bool(drop_params)
+        self.is_azure_target = is_azure_target
+        self.azure_api_version = azure_api_version
+        self.max_context_length = max_context_length
+        self.supports_reasoning = supports_reasoning
+        self.supports_function_calling = supports_function_calling
+        self.thinking_policy = thinking_policy or ThinkingControlPolicy()
+        self.tool_call_policy = tool_call_policy or ToolCallPolicy()
+
+    def build(
+        self,
+        inputs: Dict[str, Any],
+        *,
+        thinking_config: Dict[str, Any] | None = None,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Return LiteLLM kwargs and normalized sampling parameters."""
+
+        self._validate_api_base()
+        raw_sampling_params = inputs.get("sampling_params") or {}
+        runtime_sampling_params = inputs.get("runtime_sampling_params")
+        if not isinstance(runtime_sampling_params, dict):
+            runtime_sampling_params = raw_sampling_params
+        request_model = inputs.get("model") or self.model_name
+        thinking_resolution = self._resolve_thinking(
+            runtime_sampling_params,
+            thinking_config or {},
+            request_model=request_model,
+        )
+        sampling_params = self._normalize_sampling_params(
+            raw_sampling_params,
+            inputs.get("num_samples"),
+            thinking_resolution=thinking_resolution,
+        )
+        stop_sequences = self._prepare_stop_sequences(sampling_params.get("stop"))
+
+        kwargs: Dict[str, Any] = {
+            "model": self._normalize_request_model(inputs.get("model") or self.model_name),
+            "messages": inputs.get("messages") or [],
+            "stream": inputs.get("stream", False),
+            "timeout": self.timeout,
+        }
+        if self.api_base:
+            kwargs["base_url"] = self.api_base
+            kwargs["api_base"] = self.api_base
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.custom_llm_provider:
+            kwargs["custom_llm_provider"] = self.custom_llm_provider
+        if self.is_azure_target:
+            kwargs["api_type"] = "azure"
+            if self.azure_api_version:
+                kwargs["api_version"] = self.azure_api_version
+        if self.headers:
+            kwargs["headers"] = dict(self.headers)
+
+        self._add_tools(kwargs, inputs)
+        kwargs.update({k: v for k, v in sampling_params.items() if v is not None})
+        if stop_sequences:
+            kwargs["stop"] = stop_sequences
+        kwargs.setdefault("n", inputs.get("num_samples"))
+
+        self._apply_thinking_kwargs(kwargs, sampling_params, thinking_resolution)
+        self._apply_runtime_passthrough(kwargs, raw_sampling_params)
+        self._apply_litellm_request_passthrough(kwargs)
+        return kwargs, sampling_params
+
+    def _validate_api_base(self) -> None:
+        if not self.api_base:
+            return
+        path = urlsplit(self.api_base).path.rstrip("/").lower()
+        if path.endswith("/chat/completions") or path.endswith("/completions"):
+            raise ValueError(
+                "api_base must be an OpenAI-compatible base URL ending at /v1, "
+                "not a concrete endpoint path such as /chat/completions. "
+                f"(error_type={INVALID_REQUEST})"
+            )
+
+    def _add_tools(self, kwargs: Dict[str, Any], inputs: Dict[str, Any]) -> None:
+        self.tool_call_policy.apply(
+            kwargs,
+            inputs,
+            supports_function_calling=self.supports_function_calling,
+            is_vllm_tool_target=self._is_vllm_tool_target(kwargs.get("model")),
+        )
+
+    def _apply_thinking_kwargs(
+        self,
+        kwargs: Dict[str, Any],
+        sampling_params: Dict[str, Any],
+        thinking_resolution: ThinkingResolution,
+    ) -> None:
+        self._merge_kwargs_patch(kwargs, thinking_resolution.kwargs_patch)
+        reasoning_effort = sampling_params.get("reasoning_effort") or thinking_resolution.kwargs_patch.get(
+            "reasoning_effort"
+        )
+        if reasoning_effort:
+            kwargs["reasoning_effort"] = reasoning_effort
+
+    def _apply_runtime_passthrough(self, kwargs: Dict[str, Any], raw_sampling_params: Dict[str, Any]) -> None:
+        for field in LITELLM_REQUEST_PASSTHROUGH_FIELDS:
+            if field in raw_sampling_params and raw_sampling_params[field] is not None:
+                self._set_passthrough_field(kwargs, field, raw_sampling_params[field])
+
+    def _apply_litellm_request_passthrough(self, kwargs: Dict[str, Any]) -> None:
+        for field in LITELLM_REQUEST_PASSTHROUGH_FIELDS:
+            if field == "drop_params":
+                value = self.litellm_request.drop_params
+                kwargs[field] = self.drop_params if value is None else value
+                continue
+            value = getattr(self.litellm_request, field)
+            if value is None:
+                continue
+            if value == {} or value == []:
+                continue
+            self._set_passthrough_field(kwargs, field, value)
+
+    def _normalize_sampling_params(
+        self,
+        params: Dict[str, Any],
+        num_samples: Optional[int],
+        *,
+        thinking_resolution: ThinkingResolution,
+    ) -> Dict[str, Any]:
+        sampling = {k: copy.deepcopy(v) for k, v in params.items() if v is not None}
+        merged_sampling = copy.deepcopy(self.base_sampling)
+        merged_sampling.update(sampling)
+        normalized: Dict[str, Any] = {}
+
+        max_tokens = (
+            merged_sampling.get("max_tokens")
+            or merged_sampling.get("max_new_tokens")
+            or self.base_sampling.get("max_new_tokens")
+        )
+        normalized["max_tokens"] = self._prepare_max_tokens(max_tokens, thinking_resolution=thinking_resolution)
+        stop_sequences = (
+            merged_sampling.get("stop_sequences")
+            or merged_sampling.get("stop")
+            or self.base_sampling.get("stop")
+        )
+        if stop_sequences:
+            normalized["stop"] = stop_sequences
+
+        for key in (
+            "temperature",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "repetition_penalty",
+            "logprobs",
+            "top_k",
+            "min_p",
+            "seed",
+            "reasoning_effort",
+        ):
+            if merged_sampling.get(key) is not None:
+                normalized[key] = merged_sampling[key]
+
+        normalized["n"] = merged_sampling.get("n") or merged_sampling.get("num_samples") or num_samples
+        return {k: v for k, v in normalized.items() if v is not None}
+
+    def _prepare_stop_sequences(self, stop: Any) -> List[str]:
+        if not stop:
+            return []
+        if isinstance(stop, str):
+            sequences = [stop]
+        elif isinstance(stop, list):
+            sequences = [s for s in stop if isinstance(s, str)]
+        else:
+            return []
+        if (self.provider or "").lower() == "anthropic":
+            sequences = [s for s in sequences if s and s.strip()]
+        return sequences
+
+    def _prepare_max_tokens(
+        self,
+        max_tokens: Any,
+        *,
+        thinking_resolution: ThinkingResolution,
+    ) -> Optional[int]:
+        if max_tokens is None:
+            return None
+        try:
+            max_tokens = int(max_tokens)
+        except (TypeError, ValueError):
+            return None
+        if max_tokens <= 0:
+            return None
+        if self.supports_reasoning and thinking_resolution.mode == "enabled":
+            target = max_tokens * 10
+            if self.max_context_length:
+                target = min(target, self.max_context_length)
+            logger.warning("Reasoning 模型 {} 调整 max_tokens 至 {}", self.model_name, target)
+            return target
+        if self.max_context_length:
+            return min(max_tokens, self.max_context_length)
+        return max_tokens
+
+    def _resolve_thinking(
+        self,
+        raw_sampling_params: Dict[str, Any],
+        thinking_config: Dict[str, Any],
+        *,
+        request_model: str,
+    ) -> ThinkingResolution:
+        merged_config: Dict[str, Any] = {}
+        for source in (self.base_sampling, thinking_config, raw_sampling_params):
+            self._merge_thinking_source(merged_config, source)
+
+        extra_body = self.litellm_request.extra_body
+        if isinstance(extra_body, dict):
+            self._merge_thinking_source(
+                merged_config,
+                {
+                    "chat_template_kwargs": extra_body.get("chat_template_kwargs"),
+                },
+            )
+        return self.thinking_policy.resolve(
+            model=self._normalize_request_model(request_model),
+            provider=self.provider,
+            custom_llm_provider=self.custom_llm_provider,
+            api_base=self.api_base,
+            thinking_config=merged_config,
+        )
+
+    def _merge_thinking_source(self, merged_config: Dict[str, Any], source: Dict[str, Any]) -> None:
+        for key in ("thinking_mode", "chat_template_kwargs", "reasoning_effort", "enable_thinking", "extra_body"):
+            if key not in source or source[key] is None:
+                continue
+            value = source[key]
+            if key == "chat_template_kwargs" and isinstance(value, dict):
+                existing = merged_config.get("chat_template_kwargs")
+                merged_config["chat_template_kwargs"] = self._deep_merge_dicts(
+                    existing if isinstance(existing, dict) else {},
+                    value,
+                )
+                enable_thinking = value.get("enable_thinking")
+                if enable_thinking is True or enable_thinking is False:
+                    merged_config["enable_thinking"] = enable_thinking
+                    merged_config["thinking_mode"] = "enabled" if enable_thinking else "disabled"
+                continue
+            if key == "extra_body" and isinstance(value, dict):
+                chat_template_kwargs = value.get("chat_template_kwargs")
+                if isinstance(chat_template_kwargs, dict):
+                    self._merge_thinking_source(
+                        merged_config,
+                        {"chat_template_kwargs": chat_template_kwargs},
+                    )
+                continue
+            merged_config[key] = copy.deepcopy(value)
+            if key == "enable_thinking" and (value is True or value is False):
+                merged_config["thinking_mode"] = "enabled" if value else "disabled"
+
+    def _set_passthrough_field(self, kwargs: Dict[str, Any], field: str, value: Any) -> None:
+        if field == "extra_body" and isinstance(value, dict):
+            existing = kwargs.get("extra_body")
+            kwargs["extra_body"] = self._deep_merge_dicts(existing if isinstance(existing, dict) else {}, value)
+            return
+        kwargs[field] = copy.deepcopy(value)
+
+    def _merge_kwargs_patch(self, kwargs: Dict[str, Any], patch: Dict[str, Any]) -> None:
+        for key, value in patch.items():
+            self._set_passthrough_field(kwargs, key, value)
+
+    @classmethod
+    def _deep_merge_dicts(cls, base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+        merged = copy.deepcopy(base)
+        for key, value in override.items():
+            existing = merged.get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                merged[key] = cls._deep_merge_dicts(existing, value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged
+
+    def _normalize_request_model(self, model_name: str) -> str:
+        if looks_like_deepseek(self.provider, model_name, self.api_base) and "/" not in model_name:
+            return f"deepseek/{model_name}"
+        return model_name
+
+    def _is_vllm_tool_target(self, request_model: str | None) -> bool:
+        model_lower = (request_model or "").lower()
+        providers = {
+            (self.provider or "").lower().replace("-", "_"),
+            (self.custom_llm_provider or "").lower().replace("-", "_"),
+        }
+        if model_lower.startswith("hosted_vllm/"):
+            return True
+        if providers & {"hosted_vllm", "vllm", "openai_compatible"}:
+            return True
+        if self.tool_call_policy.has_declared_vllm_tool_support():
+            return True
+        return False
+
+    normalize_custom_provider = staticmethod(normalize_custom_provider)

--- a/src/gage_eval/role/model/backends/litellm/response_normalizer.py
+++ b/src/gage_eval/role/model/backends/litellm/response_normalizer.py
@@ -1,0 +1,600 @@
+"""Normalize LiteLLM responses into the GAGE backend result contract."""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from typing import Any, Dict, Iterable
+
+from loguru import logger
+
+from gage_eval.role.model.backends.litellm.policies import ToolCallPolicy
+from gage_eval.role.model.reasoning import extract_reasoning_content, strip_thinking_tags
+
+
+class LiteLLMResponseNormalizer:
+    """Normalizes LiteLLM chat completions and stream chunks."""
+
+    _MAX_SUMMARY_DEPTH = 5
+    _MAX_SUMMARY_ITEMS = 20
+    _MAX_SUMMARY_LIST_ITEMS = 10
+    _MAX_SUMMARY_STRING_CHARS = 128
+    _SECRET_KEY_NAMES = {
+        "api_key",
+        "apikey",
+        "authorization",
+        "password",
+        "secret",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+    }
+
+    def normalize(self, raw: Any, request_context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        """Normalizes a non-streaming LiteLLM completion response.
+
+        Args:
+            raw: LiteLLM response object or JSON-like dictionary.
+            request_context: Optional request metadata used for thinking mismatch
+                checks and observation summaries.
+
+        Returns:
+            A GAGE result dictionary containing answer, raw_response, usage,
+            reasoning_content, reasoning_details, tool_calls, finish_reason,
+            and metadata.
+        """
+
+        context = dict(request_context or {})
+        raw_response = self.to_jsonable(raw)
+        choice = self._first_choice(raw)
+        message = self._choice_message(choice)
+        answer = self._content_to_text(self._field(message, "content"))
+        reasoning_details = self.to_jsonable(self._field(message, "reasoning_details"))
+        reasoning, reasoning_source = self._extract_reasoning(message)
+        answer, tag_reasoning = self._strip_answer_thinking_tags(answer)
+        if tag_reasoning and not reasoning:
+            reasoning = tag_reasoning
+            reasoning_source = "think_tags"
+
+        tool_calls = ToolCallPolicy.normalize_tool_calls(self._field(message, "tool_calls"))
+        finish_reason = self._field(choice, "finish_reason")
+        usage = self.to_jsonable(self._field(raw, "usage"))
+
+        metadata: Dict[str, Any] = {}
+        self._preserve_thinking_metadata(metadata, message)
+        self._apply_reasoning_metadata(
+            metadata,
+            reasoning=reasoning,
+            reasoning_source=reasoning_source,
+            reasoning_details=reasoning_details,
+            usage=usage,
+            raw_response=raw_response,
+            tool_calls=tool_calls,
+            request_context=context,
+        )
+
+        return {
+            "answer": answer,
+            "raw_response": raw_response,
+            "usage": usage,
+            "reasoning_content": reasoning,
+            "reasoning_details": reasoning_details,
+            "tool_calls": tool_calls,
+            "finish_reason": str(finish_reason) if finish_reason is not None else None,
+            "metadata": metadata,
+        }
+
+    def normalize_stream(self, chunks: Iterable[Any], request_context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        """Normalizes sync streaming LiteLLM chunks into one GAGE result."""
+
+        context = dict(request_context or {})
+        collected_chunks: list[Any] = []
+        answer_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        reasoning_source: str | None = None
+        reasoning_details: list[Any] = []
+        tool_call_state: Dict[Any, Dict[str, Any]] = {}
+        usage: Any = None
+        finish_reason: Any = None
+        thinking_blocks: list[Any] = []
+
+        for chunk in chunks:
+            collected_chunks.append(chunk)
+            chunk_usage = self._field(chunk, "usage")
+            if chunk_usage is not None:
+                usage = chunk_usage
+
+            choice = self._first_choice(chunk)
+            if choice is None:
+                continue
+            chunk_finish_reason = self._field(choice, "finish_reason")
+            if chunk_finish_reason is not None:
+                finish_reason = chunk_finish_reason
+
+            delta = self._choice_message(choice)
+            content = self._content_to_text(self._field(delta, "content"))
+            if content:
+                answer_parts.append(content)
+
+            reasoning, source = self._extract_reasoning(delta)
+            if reasoning:
+                reasoning_parts.append(reasoning)
+                reasoning_source = reasoning_source or source
+
+            details_delta = self._field(delta, "reasoning_details")
+            if details_delta is not None:
+                reasoning_details.extend(self._as_list(self.to_jsonable(details_delta)))
+
+            block = self._field(delta, "thinking_blocks")
+            if block is not None:
+                if isinstance(block, list):
+                    thinking_blocks.extend(block)
+                else:
+                    thinking_blocks.append(block)
+
+            for tool_call_delta in self._as_list(self._field(delta, "tool_calls")):
+                ToolCallPolicy.merge_tool_call_delta(tool_call_state, tool_call_delta)
+
+        answer = "".join(answer_parts)
+        reasoning = "".join(reasoning_parts) if reasoning_parts else None
+        answer, tag_reasoning = self._strip_answer_thinking_tags(answer)
+        if tag_reasoning and not reasoning:
+            reasoning = tag_reasoning
+            reasoning_source = "think_tags"
+
+        tool_calls = ToolCallPolicy.normalize_tool_calls(list(tool_call_state.values()))
+        raw_response = self.to_jsonable(collected_chunks)
+        usage = self.to_jsonable(usage)
+        normalized_reasoning_details = reasoning_details or None
+        metadata: Dict[str, Any] = {}
+        if thinking_blocks:
+            metadata["thinking_blocks"] = self.to_jsonable(thinking_blocks)
+        self._apply_reasoning_metadata(
+            metadata,
+            reasoning=reasoning,
+            reasoning_source=reasoning_source,
+            reasoning_details=normalized_reasoning_details,
+            usage=usage,
+            raw_response=raw_response,
+            tool_calls=tool_calls,
+            request_context=context,
+        )
+
+        return {
+            "answer": answer,
+            "raw_response": raw_response,
+            "usage": usage,
+            "reasoning_content": reasoning,
+            "reasoning_details": normalized_reasoning_details,
+            "tool_calls": tool_calls,
+            "finish_reason": str(finish_reason) if finish_reason is not None else None,
+            "metadata": metadata,
+        }
+
+    def build_observation_summary(
+        self,
+        request_kwargs: Dict[str, Any],
+        response_or_result: Any,
+        request_context: Dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        """Builds a compact, non-sensitive request/response summary."""
+
+        context = dict(request_context or {})
+        result = response_or_result if isinstance(response_or_result, dict) else self.normalize(response_or_result, context)
+        metadata = result.get("metadata") if isinstance(result.get("metadata"), dict) else {}
+        api_base = context.get("api_base") or request_kwargs.get("api_base") or request_kwargs.get("base_url")
+        usage = result.get("usage")
+        latency_ms = context.get("latency_ms", result.get("latency_ms"))
+        tool_calls = result.get("tool_calls") if isinstance(result.get("tool_calls"), list) else []
+        answer = result.get("answer") or ""
+
+        summary: Dict[str, Any] = {
+            "provider": context.get("provider") or request_kwargs.get("custom_llm_provider"),
+            "model": context.get("model") or request_kwargs.get("model"),
+            "api_base_hash": self._hash_text(api_base),
+            "route_mode": context.get("route_mode"),
+            "topology": self._summarize_topology(context.get("topology")),
+            "resolved_thinking_mode": context.get("resolved_thinking_mode")
+            or context.get("thinking_mode")
+            or metadata.get("thinking_mode"),
+            "effective_thinking_mode": metadata.get("thinking_effective"),
+            "modality_counts": self._count_modalities(request_kwargs.get("messages")),
+            "tool_count": len(self._as_list(request_kwargs.get("tools"))),
+            "tool_call_count": len(tool_calls),
+            "has_tool_calls": bool(tool_calls),
+            "parallel_tool_calls": request_kwargs.get("parallel_tool_calls"),
+            "retry_owner": context.get("retry_owner"),
+            "finish_reason": result.get("finish_reason"),
+            "usage": self.to_jsonable(usage),
+            "latency_ms": round(float(latency_ms), 3) if latency_ms is not None else None,
+            "answer_chars": len(str(answer)),
+            "stream": context.get("stream"),
+        }
+        compact_summary = {key: value for key, value in summary.items() if value is not None}
+        return self._sanitize_observation_summary(compact_summary)
+
+    @classmethod
+    def to_jsonable(cls, obj: Any) -> Any:
+        """Converts LiteLLM response objects into JSON-safe values."""
+
+        try:
+            if obj is None or isinstance(obj, (str, int, float, bool)):
+                return obj
+            if isinstance(obj, dict):
+                return {key: cls.to_jsonable(value) for key, value in obj.items()}
+            if isinstance(obj, (list, tuple)):
+                return [cls.to_jsonable(value) for value in obj]
+            if hasattr(obj, "model_dump"):
+                return cls.to_jsonable(obj.model_dump())
+            if hasattr(obj, "__dict__"):
+                return {key: cls.to_jsonable(value) for key, value in vars(obj).items() if not key.startswith("_")}
+            return str(obj)
+        except Exception:  # pragma: no cover - defensive around third-party response objects
+            return str(obj)
+
+    def _extract_reasoning(self, message: Any) -> tuple[str | None, str | None]:
+        reasoning = extract_reasoning_content(message)
+        if reasoning:
+            return reasoning, "reasoning_content"
+
+        reasoning_details = self._reasoning_details_text(self._field(message, "reasoning_details"))
+        if reasoning_details:
+            return reasoning_details, "reasoning_details"
+        return None, None
+
+    def _preserve_thinking_metadata(self, metadata: Dict[str, Any], message: Any) -> None:
+        thinking_blocks = self._field(message, "thinking_blocks")
+        if thinking_blocks is not None:
+            metadata["thinking_blocks"] = self.to_jsonable(thinking_blocks)
+
+    def _apply_reasoning_metadata(
+        self,
+        metadata: Dict[str, Any],
+        *,
+        reasoning: str | None,
+        reasoning_source: str | None,
+        reasoning_details: Any,
+        usage: Any,
+        raw_response: Any,
+        tool_calls: list[Dict[str, Any]],
+        request_context: Dict[str, Any],
+    ) -> None:
+        observed_source = reasoning_source or self._observed_reasoning_source(
+            reasoning_details=reasoning_details,
+            usage=usage,
+            raw_response=raw_response,
+        )
+        if reasoning_source:
+            metadata["reasoning_source"] = reasoning_source
+        elif observed_source:
+            metadata["reasoning_source"] = observed_source
+
+        expected_mode = self._expected_thinking_mode(request_context)
+        if expected_mode:
+            metadata["thinking_mode"] = expected_mode
+
+        observed_mode = "enabled" if reasoning or observed_source else "disabled"
+        metadata["thinking_effective"] = observed_mode
+
+        if tool_calls and (expected_mode == "enabled" or observed_mode == "enabled") and "thinking_blocks" not in metadata:
+            metadata["thinking_blocks_missing"] = True
+
+        mismatch = self._thinking_mismatch(expected_mode, observed_mode, observed_source)
+        if not mismatch:
+            return
+
+        metadata["thinking_mismatch"] = mismatch
+        on_mismatch = self._policy_value(request_context.get("thinking_policy"), "on_mismatch", "warn_and_continue")
+        message = f"response_mismatch: expected thinking={expected_mode}, observed thinking={observed_mode}"
+        if on_mismatch == "fail_fast":
+            raise ValueError(message)
+        if on_mismatch == "warn_and_continue":
+            logger.warning(message)
+
+    @staticmethod
+    def _thinking_mismatch(
+        expected_mode: str | None,
+        observed_mode: str,
+        reasoning_source: str | None,
+    ) -> Dict[str, Any] | None:
+        if expected_mode not in {"enabled", "disabled"}:
+            return None
+        if expected_mode == observed_mode:
+            return None
+        mismatch: Dict[str, Any] = {
+            "expected": expected_mode,
+            "observed": observed_mode,
+            "error_type": "response_mismatch",
+        }
+        if reasoning_source:
+            mismatch["reasoning_source"] = reasoning_source
+        return mismatch
+
+    @classmethod
+    def _expected_thinking_mode(cls, request_context: Dict[str, Any]) -> str | None:
+        for key in ("expected_thinking_mode", "resolved_thinking_mode", "thinking_mode"):
+            value = request_context.get(key)
+            normalized = cls._normalize_mode(value)
+            if normalized:
+                return normalized
+        return None
+
+    def _observed_reasoning_source(
+        self,
+        *,
+        reasoning_details: Any,
+        usage: Any,
+        raw_response: Any,
+    ) -> str | None:
+        if self._has_reasoning_details(reasoning_details):
+            return "reasoning_details"
+        if self._has_positive_reasoning_tokens(usage):
+            return "usage_reasoning_tokens"
+        if self._has_positive_reasoning_tokens(raw_response):
+            return "raw_reasoning_tokens"
+        return None
+
+    @classmethod
+    def _has_reasoning_details(cls, reasoning_details: Any) -> bool:
+        if reasoning_details is None:
+            return False
+        if isinstance(reasoning_details, (list, tuple, dict, str)):
+            return bool(reasoning_details)
+        return True
+
+    @classmethod
+    def _has_positive_reasoning_tokens(cls, value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key == "reasoning_tokens" and cls._is_positive_number(item):
+                    return True
+                if cls._has_positive_reasoning_tokens(item):
+                    return True
+            return False
+        if isinstance(value, (list, tuple)):
+            return any(cls._has_positive_reasoning_tokens(item) for item in value)
+        return False
+
+    @staticmethod
+    def _is_positive_number(value: Any) -> bool:
+        try:
+            return float(value) > 0
+        except (TypeError, ValueError):
+            return False
+
+    @staticmethod
+    def _normalize_mode(value: Any) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip().lower().replace("-", "_")
+        if normalized in {"enabled", "enable", "true", "on"}:
+            return "enabled"
+        if normalized in {"disabled", "disable", "false", "off"}:
+            return "disabled"
+        if normalized in {"auto", "default", "unknown"}:
+            return normalized
+        return None
+
+    @staticmethod
+    def _policy_value(policy: Any, key: str, default: Any = None) -> Any:
+        if policy is None:
+            return default
+        if isinstance(policy, dict):
+            return policy.get(key, default)
+        return getattr(policy, key, default)
+
+    @classmethod
+    def _first_choice(cls, response: Any) -> Any:
+        choices = cls._field(response, "choices")
+        if not choices:
+            return None
+        try:
+            return choices[0]
+        except (KeyError, TypeError, IndexError):
+            return None
+
+    @classmethod
+    def _choice_message(cls, choice: Any) -> Any:
+        return cls._field(choice, "message") or cls._field(choice, "delta") or {}
+
+    @classmethod
+    def _content_to_text(cls, content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "".join(cls._content_piece(part) for part in content)
+        return str(content)
+
+    @classmethod
+    def _content_piece(cls, part: Any) -> str:
+        if isinstance(part, str):
+            return part
+        text = cls._field(part, "text")
+        if text is not None:
+            return str(text)
+        content = cls._field(part, "content")
+        if content is not None and cls._field(part, "type") in {"text", "input_text"}:
+            return str(content)
+        return ""
+
+    @staticmethod
+    def _strip_answer_thinking_tags(answer: str) -> tuple[str, str | None]:
+        if not answer:
+            return answer, None
+        return strip_thinking_tags(answer)
+
+    @classmethod
+    def _reasoning_details_text(cls, reasoning_details: Any) -> str | None:
+        if reasoning_details is None:
+            return None
+        parts = cls._readable_reasoning_parts(reasoning_details)
+        if not parts:
+            return None
+        return "\n".join(part for part in parts if part)
+
+    @classmethod
+    def _readable_reasoning_parts(cls, value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, (list, tuple)):
+            parts: list[str] = []
+            for item in value:
+                parts.extend(cls._readable_reasoning_parts(item))
+            return parts
+        for key in ("text", "content", "reasoning", "summary"):
+            item = cls._field(value, key)
+            if isinstance(item, str):
+                return [item]
+            if isinstance(item, (list, tuple)):
+                return cls._readable_reasoning_parts(item)
+        return []
+
+    @staticmethod
+    def _hash_text(value: Any) -> str | None:
+        if not value:
+            return None
+        return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:16]
+
+    @classmethod
+    def _count_modalities(cls, messages: Any) -> Dict[str, int]:
+        counts: Counter[str] = Counter()
+        for message in cls._as_list(messages):
+            content = cls._field(message, "content")
+            if isinstance(content, str):
+                counts["text"] += 1
+                continue
+            for block in cls._as_list(content):
+                block_type = cls._field(block, "type")
+                if block_type in {"text", "input_text"}:
+                    counts["text"] += 1
+                elif block_type in {"image", "image_url"}:
+                    counts["image"] += 1
+                elif block_type in {"audio", "audio_url", "input_audio"}:
+                    counts["audio"] += 1
+                elif block_type in {"video", "video_url"}:
+                    counts["video"] += 1
+                elif block_type in {"file", "file_url"}:
+                    counts["file"] += 1
+                elif block_type == "document":
+                    counts["document"] += 1
+                elif block_type:
+                    counts["other"] += 1
+        return dict(counts)
+
+    @classmethod
+    def _summarize_topology(cls, topology: Any) -> Any:
+        if topology is None:
+            return None
+        if not isinstance(topology, dict):
+            return cls._safe_scalar(topology)
+
+        summary: Dict[str, Any] = {}
+        for key, value in topology.items():
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                summary[key] = cls._safe_scalar(value)
+            elif isinstance(value, dict):
+                summary[key] = {"keys": sorted(str(item) for item in value.keys())}
+            elif isinstance(value, list):
+                summary[key] = {"count": len(value)}
+            else:
+                summary[key] = type(value).__name__
+        return summary
+
+    @staticmethod
+    def _safe_scalar(value: Any) -> Any:
+        if isinstance(value, str) and len(value) > 128:
+            return {"chars": len(value), "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]}
+        return value
+
+    @classmethod
+    def _sanitize_observation_summary(cls, summary: Dict[str, Any]) -> Dict[str, Any]:
+        sanitized = cls._sanitize_summary_value(summary)
+        return sanitized if isinstance(sanitized, dict) else {}
+
+    @classmethod
+    def _sanitize_summary_value(cls, value: Any, *, key: str | None = None, depth: int = 0) -> Any:
+        if key is not None and cls._is_secret_key(key):
+            return "[REDACTED]"
+        if isinstance(value, str):
+            return cls._sanitize_summary_string(value)
+        if value is None or isinstance(value, (int, float, bool)):
+            return value
+        if depth >= cls._MAX_SUMMARY_DEPTH:
+            return cls._container_summary(value)
+        if isinstance(value, dict):
+            sanitized: Dict[str, Any] = {}
+            items = list(value.items())
+            for item_key, item_value in items[: cls._MAX_SUMMARY_ITEMS]:
+                sanitized[str(item_key)] = cls._sanitize_summary_value(
+                    item_value,
+                    key=str(item_key),
+                    depth=depth + 1,
+                )
+            if len(items) > cls._MAX_SUMMARY_ITEMS:
+                sanitized["_truncated_items"] = len(items) - cls._MAX_SUMMARY_ITEMS
+            return sanitized
+        if isinstance(value, (list, tuple)):
+            sanitized_list = [
+                cls._sanitize_summary_value(item, depth=depth + 1)
+                for item in list(value)[: cls._MAX_SUMMARY_LIST_ITEMS]
+            ]
+            if len(value) > cls._MAX_SUMMARY_LIST_ITEMS:
+                sanitized_list.append({"_truncated_items": len(value) - cls._MAX_SUMMARY_LIST_ITEMS})
+            return sanitized_list
+        return str(value)
+
+    @classmethod
+    def _sanitize_summary_string(cls, value: str) -> Any:
+        if len(value) <= cls._MAX_SUMMARY_STRING_CHARS and not value.startswith("data:"):
+            return value
+        kind = "data_url" if value.startswith("data:") else "base64" if cls._looks_like_base64(value) else "truncated"
+        return {
+            "kind": kind,
+            "chars": len(value),
+            "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest()[:16],
+        }
+
+    @classmethod
+    def _looks_like_base64(cls, value: str) -> bool:
+        if len(value) <= cls._MAX_SUMMARY_STRING_CHARS:
+            return False
+        sample = value[: min(len(value), 512)].strip()
+        if not sample:
+            return False
+        base64_chars = sum(1 for char in sample if char.isalnum() or char in {"+", "/", "="})
+        return base64_chars / len(sample) > 0.95
+
+    @classmethod
+    def _is_secret_key(cls, key: str) -> bool:
+        normalized = key.strip().lower().replace("-", "_")
+        return normalized in cls._SECRET_KEY_NAMES or normalized.endswith("_api_key")
+
+    @staticmethod
+    def _container_summary(value: Any) -> Dict[str, Any]:
+        if isinstance(value, dict):
+            return {"kind": "dict", "keys": sorted(str(key) for key in value.keys())[:10]}
+        if isinstance(value, (list, tuple)):
+            return {"kind": "list", "items": len(value)}
+        return {"kind": type(value).__name__}
+
+    @staticmethod
+    def _field(obj: Any, name: str, default: Any = None) -> Any:
+        if isinstance(obj, dict):
+            return obj.get(name, default)
+        return getattr(obj, name, default)
+
+    @staticmethod
+    def _as_list(value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        return [value]

--- a/src/gage_eval/role/model/backends/litellm/router_factory.py
+++ b/src/gage_eval/role/model/backends/litellm/router_factory.py
@@ -1,0 +1,37 @@
+"""Factory for GAGE-managed LiteLLM Router instances."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from gage_eval.role.model.backends.litellm.service_profile import _model_to_dict
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig, assert_litellm_capabilities
+
+
+class LiteLLMRouterFactory:
+    """Construct a LiteLLM Router when backend config requests internal routing."""
+
+    def __init__(self, litellm_module: Any) -> None:
+        self._litellm = litellm_module
+
+    def build(self, cfg: LiteLLMBackendConfig) -> Any | None:
+        route_mode = cfg.resolved_route_mode()
+        if route_mode == "direct":
+            return None
+        if not cfg.model_list:
+            raise ValueError("route_mode='router' requires non-empty model_list")
+
+        assert_litellm_capabilities(require_router=True, litellm_module=self._litellm)
+        return self._litellm.Router(
+            model_list=self._model_list_payload(cfg),
+            **self._router_settings_payload(cfg),
+        )
+
+    @staticmethod
+    def _model_list_payload(cfg: LiteLLMBackendConfig) -> list[Dict[str, Any]]:
+        return [_model_to_dict(deployment) for deployment in cfg.model_list]
+
+    @staticmethod
+    def _router_settings_payload(cfg: LiteLLMBackendConfig) -> Dict[str, Any]:
+        settings = _model_to_dict(cfg.router_settings, exclude_none=True)
+        return {key: value for key, value in settings.items() if value is not None}

--- a/src/gage_eval/role/model/backends/litellm/service_profile.py
+++ b/src/gage_eval/role/model/backends/litellm/service_profile.py
@@ -1,0 +1,105 @@
+"""Describe LiteLLM/vLLM routing profile metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal
+
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+
+
+def _model_to_dict(value: Any, *, exclude_none: bool = False) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        data = dict(value)
+        if exclude_none:
+            return {key: item for key, item in data.items() if item is not None}
+        return data
+    if hasattr(value, "model_dump"):
+        return value.model_dump(exclude_none=exclude_none)
+    if hasattr(value, "dict"):
+        return value.dict(exclude_none=exclude_none)
+    return dict(value)
+
+
+@dataclass(frozen=True)
+class VLLMServiceProfile:
+    """Runtime profile for direct, gateway, and internal Router LiteLLM calls."""
+
+    mode: Literal["direct", "router"]
+    model: str
+    api_base: str | None = None
+    deployments: List[Dict[str, Any]] = field(default_factory=list)
+    topology: Dict[str, Any] = field(default_factory=dict)
+    reasoning_parser: str | None = None
+    chat_template_defaults: Dict[str, Any] | None = None
+    language_model_only: bool | None = None
+
+    @classmethod
+    def from_config(cls, cfg: LiteLLMBackendConfig) -> "VLLMServiceProfile":
+        generation_parameters = cfg.generation_parameters.to_dict()
+        chat_template_defaults = generation_parameters.get("chat_template_kwargs")
+        return cls(
+            mode=cfg.resolved_route_mode(),
+            model=cfg.model,
+            api_base=cfg.api_base,
+            deployments=[_model_to_dict(deployment) for deployment in cfg.model_list],
+            topology=_model_to_dict(cfg.vllm.topology, exclude_none=True),
+            reasoning_parser=cfg.vllm.reasoning_parser,
+            chat_template_defaults=chat_template_defaults,
+            language_model_only=cfg.vllm.topology.language_model_only,
+        )
+
+    def validate_deployment_consistency(self) -> List[str]:
+        """Validate known per-deployment vLLM metadata without inventing it."""
+
+        if self.mode != "router" or len(self.deployments) <= 1:
+            return []
+
+        parsers = self._deployment_values("reasoning_parser")
+        chat_template_defaults = self._deployment_values("chat_template_defaults")
+        language_model_only = self._deployment_values("language_model_only")
+
+        self._fail_on_inconsistent_values("reasoning_parser", parsers)
+        self._fail_on_inconsistent_values("chat_template_defaults", chat_template_defaults)
+        self._fail_on_inconsistent_values("language_model_only", language_model_only)
+
+        top_level_profile_declared = (
+            self.reasoning_parser is not None
+            or self.chat_template_defaults is not None
+            or self.language_model_only is not None
+        )
+        per_deployment_profile_declared = bool(parsers or chat_template_defaults or language_model_only)
+        if not per_deployment_profile_declared and top_level_profile_declared:
+            return [
+                "per-deployment vLLM metadata not provided; assuming declared profile applies to all deployments"
+            ]
+        return []
+
+    def _deployment_values(self, field_name: str) -> List[Any]:
+        values: List[Any] = []
+        for deployment in self.deployments:
+            value = self._deployment_metadata_value(deployment, field_name)
+            if value is not None:
+                values.append(value)
+        return values
+
+    @staticmethod
+    def _deployment_metadata_value(deployment: Dict[str, Any], field_name: str) -> Any:
+        vllm_metadata = deployment.get("vllm")
+        if isinstance(vllm_metadata, dict) and vllm_metadata.get(field_name) is not None:
+            return vllm_metadata[field_name]
+        if field_name == "language_model_only" and isinstance(vllm_metadata, dict):
+            topology = vllm_metadata.get("topology")
+            if isinstance(topology, dict) and topology.get("language_model_only") is not None:
+                return topology["language_model_only"]
+        if deployment.get(field_name) is not None:
+            return deployment[field_name]
+        return None
+
+    @staticmethod
+    def _fail_on_inconsistent_values(field_name: str, values: List[Any]) -> None:
+        if not values:
+            return
+        first = values[0]
+        if any(value != first for value in values[1:]):
+            raise ValueError(f"model_list deployments have inconsistent vLLM {field_name}")

--- a/src/gage_eval/role/model/backends/litellm_backend.py
+++ b/src/gage_eval/role/model/backends/litellm_backend.py
@@ -2,19 +2,56 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+import asyncio
+import inspect
 import json
 import os
-import threading
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from collections.abc import Mapping
+from typing import Any, Dict, List, Tuple
 
 from loguru import logger
 
 from gage_eval.role.model.backends.base_backend import EngineBackend
-from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+from gage_eval.role.model.backends.litellm.credential_resolver import ProviderCredentialResolver
+from gage_eval.role.model.backends.litellm.errors import (
+    DEPENDENCY_UNAVAILABLE,
+    LiteLLMBackendError,
+    status_code_from_error,
+)
+from gage_eval.role.model.backends.litellm.message_normalizer import MultimodalMessageNormalizer
+from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+from gage_eval.role.model.backends.litellm.policies import ThinkingControlPolicy, ToolCallPolicy
+from gage_eval.role.model.backends.litellm.provider_detection import (
+    infer_provider_from_model,
+    is_default_local_litellm_gateway,
+    is_explicit_litellm_gateway,
+    looks_like_azure,
+    looks_like_deepseek,
+    looks_like_grok,
+    looks_like_kimi,
+    normalize_custom_provider,
+)
+from gage_eval.role.model.backends.litellm.request_builder import LiteLLMRequestBuilder
+from gage_eval.role.model.backends.litellm.response_normalizer import LiteLLMResponseNormalizer
+from gage_eval.role.model.backends.litellm.router_factory import LiteLLMRouterFactory
+from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig, assert_litellm_capabilities
 from gage_eval.registry import registry
-from gage_eval.utils.messages import normalize_messages_for_template, stringify_message_content
+from gage_eval.utils.messages import normalize_messages_for_template
+
+
+ROUTER_COMPLETION_DIRECT_TRANSPORT_FIELDS = frozenset(
+    {
+        "api_base",
+        "base_url",
+        "api_key",
+        "custom_llm_provider",
+        "api_type",
+        "api_version",
+        "headers",
+    }
+)
 
 
 @registry.asset(
@@ -22,19 +59,25 @@ from gage_eval.utils.messages import normalize_messages_for_template, stringify_
     "litellm",
     desc="LiteLLM backend for unified provider access (Grok/Kimi base URLs + param normalization)",
     tags=("llm", "remote", "api"),
-    modalities=("text",),
+    modalities=("text", "vision", "audio"),
 )
 class LiteLLMBackend(EngineBackend):
     """LiteLLM backend with provider inference and sampling normalization."""
-
-    _litellm_module_state_lock = threading.RLock()
 
     def __init__(self, config: Dict[str, Any]) -> None:
         self.http_retry_mode = "native"
         self.transport = "http"
         self._litellm = None
+        self._router = None
+        self._service_profile = None
+        self._thinking_policy = None
+        self._tool_call_policy = None
+        self._response_normalizer = None
+        self._message_normalizer = None
         self._supports_reasoning_fn = None
+        self._supports_function_calling_fn = None
         self._custom_llm_provider = None
+        self._model_server_lifecycle = config.get("_model_server_lifecycle") or ModelServerLifecycle()
         super().__init__(config)
 
     # ------------------------------------------------------------------ #
@@ -43,22 +86,25 @@ class LiteLLMBackend(EngineBackend):
     def load_model(self, config_dict: Dict[str, Any]):
         # STEP 1: Resolve provider-specific routing, credentials, and sampling defaults.
         self._cfg = LiteLLMBackendConfig(**config_dict)
+        self._apply_deprecated_mock_config()
+        if self._cfg.model_server.enabled:
+            self._model_server_lifecycle.ensure_ready(self._cfg.model_server)
         self._tool_choice_default = config_dict.get("tool_choice")
         self.model_name = self._cfg.model
-        self.provider = self._cfg.provider or self._infer_provider(self.model_name)
+        self.provider = self._cfg.provider or infer_provider_from_model(self.model_name)
         self.api_base = self._cfg.api_base
-        self._is_deepseek_target = self._looks_like_deepseek(self.provider, self.model_name, self.api_base)
+        self._is_deepseek_target = looks_like_deepseek(self.provider, self.model_name, self.api_base)
         self.api_key = None
         self.headers = dict(self._cfg.extra_headers or {})
         self._timeout = self._cfg.timeout
-        self._max_retries = max(1, int(self._cfg.max_retries))
+        self._max_retries = self._resolve_backend_retry_budget()
         self._retry_sleep = float(self._cfg.retry_sleep)
         self._retry_multiplier = max(1.0, float(self._cfg.retry_multiplier))
         self._max_context_length = self._cfg.max_model_length
         self._base_sampling = self._cfg.generation_parameters.to_dict()
-        self._is_kimi_target = self._looks_like_kimi(self.provider, self.model_name, self.api_base)
-        self._is_grok_target = self._looks_like_grok(self.provider, self.model_name, self.api_base)
-        self._is_azure_target = self._looks_like_azure(self.provider, self.model_name, self.api_base)
+        self._is_kimi_target = looks_like_kimi(self.provider, self.model_name, self.api_base)
+        self._is_grok_target = looks_like_grok(self.provider, self.model_name, self.api_base)
+        self._is_azure_target = looks_like_azure(self.provider, self.model_name, self.api_base)
         if self._is_deepseek_target and (not self.provider or self.provider.lower() == "openai"):
             self.provider = "deepseek"
         if not self.provider and self._is_grok_target:
@@ -79,7 +125,17 @@ class LiteLLMBackend(EngineBackend):
                 if self.api_base:
                     self.api_base = self.api_base.rstrip("/")
 
-        self.api_key = self._resolve_api_key()
+        # NOTE: Normalize `custom_llm_provider`: prefer an explicit user value, then
+        # fall back to provider inference.
+        self._custom_llm_provider = normalize_custom_provider(
+            getattr(self._cfg, "custom_llm_provider", None) or self.provider
+        )
+        self.api_key = ProviderCredentialResolver(
+            self._cfg,
+            provider=self.provider,
+            custom_llm_provider=self._custom_llm_provider,
+            topology_kind=self._vllm_topology_kind(),
+        ).resolve()
         self._azure_api_version = self._cfg.azure_api_version or os.getenv("AZURE_OPENAI_API_VERSION")
         if self._is_azure_target and not self._azure_api_version:
             self._azure_api_version = "2024-02-15-preview"
@@ -87,21 +143,60 @@ class LiteLLMBackend(EngineBackend):
         if self._cfg.force_kimi_direct or self._cfg.prefer_litellm_kimi:
             logger.warning("force_kimi_direct/prefer_litellm_kimi 已废弃，LiteLLM 现统一走 litellm 调用路径")
 
-        # NOTE: Normalize `custom_llm_provider`: prefer an explicit user value, then
-        # fall back to provider inference.
-        self._custom_llm_provider = self._normalize_custom_provider(
-            getattr(self._cfg, "custom_llm_provider", None) or self.provider
-        )
-
         try:  # pragma: no cover - optional dependency
             import litellm  # type: ignore
         except ImportError as exc:  # pragma: no cover
-            raise RuntimeError("liteLLM is not installed") from exc
+            raise LiteLLMBackendError("LiteLLM is not installed", DEPENDENCY_UNAVAILABLE) from exc
+        assert_litellm_capabilities(litellm_module=litellm)
 
-        # STEP 2: Capture the imported module and defer mutable flag changes to request scope.
+        # STEP 2: Capture the imported module. Request-specific options are passed
+        # through completion kwargs to avoid mutating LiteLLM module globals.
         self._litellm = litellm
         self._supports_reasoning_fn = getattr(litellm, "supports_reasoning", None)
+        self._supports_function_calling_fn = getattr(litellm, "supports_function_calling", None)
+        self._service_profile = VLLMServiceProfile.from_config(self._cfg)
+        for warning in self._service_profile.validate_deployment_consistency():
+            logger.warning("LiteLLM service profile: {}", warning)
+        self._message_normalizer = MultimodalMessageNormalizer(
+            self._cfg.multimodal,
+            service_profile=self._service_profile,
+        )
+        self._thinking_policy = ThinkingControlPolicy.from_config(
+            self._cfg.thinking_policy,
+            service_profile=self._service_profile,
+        )
+        self._tool_call_policy = ToolCallPolicy.from_config(self._cfg.tool_calling)
+        self._response_normalizer = LiteLLMResponseNormalizer()
+        self._router = LiteLLMRouterFactory(litellm).build(self._cfg)
         return None
+
+    def _apply_deprecated_mock_config(self) -> None:
+        deprecated_fields = []
+        if self._cfg.mock_api_base:
+            deprecated_fields.append("mock_api_base")
+            if not self._cfg.api_base:
+                self._cfg.api_base = self._cfg.mock_api_base
+        if self._cfg.mock_api_key:
+            deprecated_fields.append("mock_api_key")
+            if not self._cfg.api_key:
+                self._cfg.api_key = self._cfg.mock_api_key
+        if self._cfg.mock_model:
+            deprecated_fields.append("mock_model")
+            if not self._cfg._field_was_explicitly_set("model"):
+                self._cfg.model = self._cfg.mock_model
+        if deprecated_fields:
+            logger.warning(
+                "LiteLLM config fields "
+                + ", ".join(deprecated_fields)
+                + " are deprecated; use api_base/api_key/model instead."
+            )
+
+    def _resolve_backend_retry_budget(self) -> int:
+        if self._cfg.resolved_route_mode() == "router":
+            return 1
+        if self._looks_like_litellm_gateway_endpoint():
+            return 1
+        return max(1, int(self._cfg.max_retries))
 
     def prepare_inputs(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         sample = payload.get("sample") or {}
@@ -114,20 +209,28 @@ class LiteLLMBackend(EngineBackend):
                 messages.append({"role": "system", "content": system_prompt})
             messages.append({"role": "user", "content": prompt})
 
-        messages = self._normalize_messages_for_provider(messages)
+        sample_sampling_params = sample.get("sampling_params") or {}
+        payload_sampling_params = payload.get("sampling_params") or {}
+        runtime_sampling_params = dict(sample_sampling_params)
+        runtime_sampling_params.update(payload_sampling_params)
 
         sampling_params = dict(self._base_sampling)
-        sampling_params.update(sample.get("sampling_params") or {})
-        sampling_params.update(payload.get("sampling_params") or {})
+        sampling_params.update(sample_sampling_params)
+        sampling_params.update(payload_sampling_params)
         tool_defs = payload.get("tools") or sample.get("tools")
         tool_choice = payload.get("tool_choice") or sample.get("tool_choice") or self._tool_choice_default
+        parallel_tool_calls = payload.get("parallel_tool_calls")
+        if parallel_tool_calls is None:
+            parallel_tool_calls = sample.get("parallel_tool_calls")
 
         return {
             "model": payload.get("model") or self.model_name,
             "messages": messages,
             "sampling_params": sampling_params,
+            "runtime_sampling_params": runtime_sampling_params,
             "tools": tool_defs,
             "tool_choice": tool_choice,
+            "parallel_tool_calls": parallel_tool_calls,
             "stream": bool(payload.get("stream", self._cfg.streaming)),
             "num_samples": payload.get("num_samples") or sampling_params.get("n"),
         }
@@ -135,168 +238,237 @@ class LiteLLMBackend(EngineBackend):
     def generate(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         return self._generate_litellm(inputs)
 
+    def invoke(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        inputs = self.prepare_inputs(payload)
+        start = time.time()
+        result = self.generate(inputs)
+        result.setdefault("latency_ms", (time.time() - start) * 1000)
+        self._enrich_result_with_reasoning(result)
+        logger.debug(
+            "Backend {} finished request latency={:.2f}ms",
+            self.__class__.__name__,
+            result["latency_ms"],
+        )
+        return result
+
+    async def ainvoke(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        inputs = self.prepare_inputs(payload)
+        start = time.time()
+        result = await self._agenerate_litellm(inputs)
+        result.setdefault("latency_ms", (time.time() - start) * 1000)
+        self._enrich_result_with_reasoning(result)
+        logger.debug(
+            "Backend {} finished request latency={:.2f}ms",
+            self.__class__.__name__,
+            result["latency_ms"],
+        )
+        return result
+
     # ------------------------------------------------------------------ #
     # LiteLLM call path                                                 #
     # ------------------------------------------------------------------ #
     def _generate_litellm(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         # STEP 1: Build isolated request kwargs and execute the LiteLLM call path.
-        kwargs, _ = self._build_litellm_kwargs(inputs)
-        stream = kwargs.pop("stream", False)
+        kwargs, request_kwargs, request_context, stream = self._prepare_completion_call(inputs)
         start = time.time()
 
         def _call():
-            with self._temporary_litellm_module_state():
-                return self._litellm.completion(stream=stream, **kwargs)
+            completion_target = self._router or self._litellm
+            return completion_target.completion(stream=stream, **kwargs)
 
         completion = self._call_with_retries(_call)
 
         # STEP 2: Normalize the response for downstream consumers and safe diagnostics.
-        if stream:
-            answer, raw_response = self._collect_stream(completion)
+        latency_ms = (time.time() - start) * 1000
+        return self._normalize_litellm_completion(
+            completion,
+            stream=stream,
+            latency_ms=latency_ms,
+            request_kwargs=request_kwargs,
+            request_context=request_context,
+        )
+
+    async def _agenerate_litellm(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        kwargs, request_kwargs, request_context, stream = self._prepare_completion_call(inputs)
+        start = time.time()
+        if self._router is not None:
+            acompletion = getattr(self._router, "acompletion", None)
+            if not callable(acompletion):
+                raise RuntimeError(
+                    "LiteLLM Router async path requires router.acompletion; "
+                    "upgrade LiteLLM or use a Router implementation with async completion support."
+                )
         else:
-            answer = self._extract_answer(completion)
-            raw_response = completion
-        raw_response = self._to_jsonable(raw_response)
-        result: Dict[str, Any] = {"answer": answer, "raw_response": raw_response}
-        if not stream and hasattr(completion, "usage"):
-            usage = getattr(completion, "usage")
-            if hasattr(usage, "model_dump"):
-                result["usage"] = usage.model_dump()
-        result.setdefault("latency_ms", (time.time() - start) * 1000)
+            acompletion = getattr(self._litellm, "acompletion", None)
+            if not callable(acompletion):
+                raise RuntimeError(
+                    "LiteLLM async path requires litellm.acompletion; "
+                    "upgrade LiteLLM or use the synchronous generate path."
+                )
+
+        async def _call():
+            return await acompletion(stream=stream, **kwargs)
+
+        completion = await self._acall_with_retries(_call)
+        if stream:
+            completion = await self._collect_async_stream(completion)
+        latency_ms = (time.time() - start) * 1000
+        return self._normalize_litellm_completion(
+            completion,
+            stream=stream,
+            latency_ms=latency_ms,
+            request_kwargs=request_kwargs,
+            request_context=request_context,
+        )
+
+    def _prepare_completion_call(
+        self,
+        inputs: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any], bool]:
+        if "messages" in inputs:
+            inputs = dict(inputs)
+            inputs["messages"] = self._normalize_messages_for_provider(inputs.get("messages") or [])
+        kwargs, _ = self._build_litellm_kwargs(inputs)
+        request_kwargs = dict(kwargs)
+        request_context = self._build_request_context(request_kwargs)
+        if self._router is not None:
+            kwargs = self._router_completion_kwargs(kwargs)
+        stream = kwargs.pop("stream", False)
+        request_context["stream"] = stream
+        return kwargs, request_kwargs, request_context, bool(stream)
+
+    def _normalize_litellm_completion(
+        self,
+        completion: Any,
+        *,
+        stream: bool,
+        latency_ms: float,
+        request_kwargs: Dict[str, Any],
+        request_context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        request_context["latency_ms"] = latency_ms
+        normalizer = self._response_normalizer or LiteLLMResponseNormalizer()
+        if stream:
+            result = normalizer.normalize_stream(completion, request_context=request_context)
+        else:
+            result = normalizer.normalize(completion, request_context=request_context)
+        result.setdefault("latency_ms", latency_ms)
+        observation_summary = normalizer.build_observation_summary(
+            request_kwargs,
+            result,
+            request_context=request_context,
+        )
+        result.setdefault("metadata", {})
+        result["metadata"]["observation_summary"] = observation_summary
         logger.info(
             "LiteLLM response summary: {}",
-            self._format_response_json(
-                self._build_response_log_summary(
-                    raw_response,
-                    answer=answer,
-                    usage=result.get("usage"),
-                    stream=stream,
-                    request_model=kwargs.get("model"),
-                    latency_ms=result.get("latency_ms"),
-                )
-            ),
+            self._format_response_json(observation_summary),
         )
         return result
 
-    @contextmanager
-    def _temporary_litellm_module_state(self):
-        """Apply LiteLLM module flags for one request and restore previous values."""
+    @staticmethod
+    async def _collect_async_stream(stream_response: Any) -> List[Any]:
+        if not hasattr(stream_response, "__aiter__"):
+            if inspect.isawaitable(stream_response):
+                stream_response = await stream_response
+            if not hasattr(stream_response, "__aiter__"):
+                if isinstance(stream_response, Mapping):
+                    return [stream_response]
+                if isinstance(stream_response, (str, bytes, bytearray)):
+                    raise RuntimeError(
+                        "LiteLLM async streaming expected an async iterator or completion-like mapping, "
+                        f"got {type(stream_response).__name__}."
+                    )
+                try:
+                    return list(stream_response)
+                except TypeError:
+                    return [stream_response]
+        chunks: List[Any] = []
+        async for chunk in stream_response:
+            chunks.append(chunk)
+        return chunks
 
-        if self._litellm is None:
-            yield
-            return
-        with self._litellm_module_state_lock:
-            previous_drop_params = getattr(self._litellm, "drop_params", None)
-            previous_verbose = getattr(self._litellm, "verbose", None)
-            had_drop_params = hasattr(self._litellm, "drop_params")
-            had_verbose = hasattr(self._litellm, "verbose")
-            self._litellm.drop_params = bool(self._cfg.drop_params)
-            self._litellm.verbose = bool(self._cfg.verbose)
-            try:
-                yield
-            finally:
-                if had_drop_params:
-                    self._litellm.drop_params = previous_drop_params
-                else:
-                    delattr(self._litellm, "drop_params")
-                if had_verbose:
-                    self._litellm.verbose = previous_verbose
-                else:
-                    delattr(self._litellm, "verbose")
+    @staticmethod
+    def _router_completion_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            key: value
+            for key, value in kwargs.items()
+            if key not in ROUTER_COMPLETION_DIRECT_TRANSPORT_FIELDS
+        }
 
     def _build_litellm_kwargs(self, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-        sampling_params = self._normalize_sampling_params(inputs.get("sampling_params") or {}, inputs.get("num_samples"))
-        stop_sequences = self._prepare_stop_sequences(sampling_params.get("stop"))
-
-        kwargs: Dict[str, Any] = {
-            "model": self._normalize_request_model(inputs.get("model") or self.model_name),
-            "messages": inputs.get("messages") or [],
-            "response_format": {"type": "text"},
-            "stream": inputs.get("stream", False),
-            "timeout": self._timeout,
-        }
-        if self.api_base:
-            kwargs["base_url"] = self.api_base
-            kwargs["api_base"] = self.api_base
-        if self.api_key:
-            kwargs["api_key"] = self.api_key
-        if self._custom_llm_provider:
-            kwargs["custom_llm_provider"] = self._custom_llm_provider
-        if self._is_azure_target:
-            kwargs["api_type"] = "azure"
-            if self._azure_api_version:
-                kwargs["api_version"] = self._azure_api_version
-        if self.headers:
-            kwargs["headers"] = dict(self.headers)
-        tool_defs = inputs.get("tools")
-        if tool_defs:
-            formatted_tools = self._format_tools(tool_defs)
-            if formatted_tools:
-                kwargs["tools"] = formatted_tools
-                tool_choice = inputs.get("tool_choice")
-                if tool_choice is not None:
-                    kwargs["tool_choice"] = tool_choice
-        kwargs.update({k: v for k, v in sampling_params.items() if v is not None})
-        if stop_sequences:
-            kwargs["stop"] = stop_sequences
-        kwargs.setdefault("n", inputs.get("num_samples"))
-
-        # STEP: Inject thinking-related parameters from base class config
-        thinking_config = self.get_thinking_config()
-        if "enable_thinking" in thinking_config:
-            kwargs["enable_thinking"] = thinking_config["enable_thinking"]
-        # Support reasoning_effort from config or per-request sampling params
-        reasoning_effort = (
-            sampling_params.get("reasoning_effort")
-            or thinking_config.get("reasoning_effort")
+        builder = LiteLLMRequestBuilder(
+            model_name=self.model_name,
+            provider=self.provider,
+            api_base=self.api_base,
+            api_key=self.api_key,
+            timeout=self._timeout,
+            headers=self.headers,
+            custom_llm_provider=self._custom_llm_provider,
+            base_sampling=self._base_sampling,
+            litellm_request=self._cfg.litellm_request,
+            drop_params=self._cfg.drop_params,
+            is_azure_target=self._is_azure_target,
+            azure_api_version=self._azure_api_version,
+            max_context_length=self._max_context_length,
+            supports_reasoning=self._supports_reasoning_model(),
+            supports_function_calling=self._supports_function_calling_model(inputs.get("model") or self.model_name),
+            thinking_policy=self._thinking_policy,
+            tool_call_policy=self._tool_call_policy,
         )
-        if reasoning_effort:
-            kwargs["reasoning_effort"] = reasoning_effort
+        return builder.build(inputs, thinking_config=self.get_thinking_config())
 
-        return kwargs, sampling_params
+    def _build_request_context(self, request_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Builds non-sensitive request metadata for response normalization."""
 
-    def _extract_answer(self, completion: Any) -> str:
-        if completion is None:
-            return ""
-        choices = getattr(completion, "choices", None)
-        if choices:
-            choice = choices[0]
-            message = getattr(choice, "message", None) or getattr(choice, "delta", None)
-            content = getattr(message, "content", None) if message else None
-            if isinstance(content, list):
-                return "".join([self._content_piece(part) for part in content])
-            return content or ""
-        if isinstance(completion, dict):
-            choices = completion.get("choices") or []
-            if choices:
-                message = choices[0].get("message") or choices[0].get("delta") or {}
-                content = message.get("content")
-                if isinstance(content, list):
-                    return "".join([self._content_piece(part) for part in content])
-                return content or ""
-        return str(completion)
+        route_mode = self._cfg.resolved_route_mode()
+        resolved_thinking_mode = self._resolved_thinking_mode_from_kwargs(request_kwargs)
+        retry_owner = self._retry_owner(route_mode)
+        return {
+            "provider": self.provider or self._custom_llm_provider,
+            "model": request_kwargs.get("model") or self.model_name,
+            "api_base": request_kwargs.get("api_base") or request_kwargs.get("base_url") or self.api_base,
+            "route_mode": route_mode,
+            "topology": dict(self._service_profile.topology) if self._service_profile else {},
+            "thinking_mode": resolved_thinking_mode,
+            "resolved_thinking_mode": resolved_thinking_mode,
+            "thinking_policy": self._cfg.thinking_policy,
+            "retry_owner": retry_owner,
+        }
 
-    def _collect_stream(self, stream_response: Any) -> Tuple[str, List[Any]]:
-        """Collect streaming chunks into a single text answer."""
+    def _resolved_thinking_mode_from_kwargs(self, request_kwargs: Dict[str, Any]) -> str:
+        extra_body = request_kwargs.get("extra_body")
+        if isinstance(extra_body, dict):
+            chat_template_kwargs = extra_body.get("chat_template_kwargs")
+            if isinstance(chat_template_kwargs, dict):
+                enable_thinking = chat_template_kwargs.get("enable_thinking")
+                if enable_thinking is True:
+                    return "enabled"
+                if enable_thinking is False:
+                    return "disabled"
+        if self._thinking_mode:
+            return str(self._thinking_mode)
+        mode = self._base_sampling.get("thinking_mode")
+        return str(mode) if mode else "auto"
 
-        chunks: List[Any] = []
-        parts: List[str] = []
-        for chunk in stream_response:
-            chunks.append(chunk)
-            choices = getattr(chunk, "choices", None)
-            if not choices and isinstance(chunk, dict):
-                choices = chunk.get("choices")
-            if not choices:
-                continue
-            delta = getattr(choices[0], "delta", None) or getattr(choices[0], "message", None)
-            if delta is None and isinstance(choices[0], dict):
-                delta = choices[0].get("delta") or choices[0].get("message")
-            content = getattr(delta, "content", None) if delta else None
-            if isinstance(content, list):
-                parts.append("".join([self._content_piece(part) for part in content]))
-            elif content:
-                parts.append(str(content))
-        return "".join(parts), chunks
+    def _supports_reasoning_model(self) -> bool:
+        if not self._supports_reasoning_fn:
+            return False
+        try:
+            return bool(self._supports_reasoning_fn(self.model_name))
+        except Exception:  # pragma: no cover - defensive around third-party helpers
+            return False
+
+    def _supports_function_calling_model(self, model_name: str | None = None) -> bool | None:
+        if not callable(self._supports_function_calling_fn):
+            return None
+        try:
+            result = self._supports_function_calling_fn(model_name or self.model_name)
+        except Exception:  # pragma: no cover - defensive around third-party helpers
+            return None
+        if result is None:
+            return None
+        return bool(result)
 
     # ------------------------------------------------------------------ #
     # Helpers                                                            #
@@ -306,144 +478,12 @@ class LiteLLMBackend(EngineBackend):
 
         if self._should_flatten_multimodal_messages():
             return normalize_messages_for_template(messages, image_placeholder="<image>")
-        if self._should_sanitize_openai_messages():
-            return self._sanitize_openai_messages(messages)
-        return messages
+        normalizer = self._message_normalizer or MultimodalMessageNormalizer(self._cfg.multimodal)
+        return normalizer.normalize(messages, service_profile=self._service_profile)
 
     def _should_flatten_multimodal_messages(self) -> bool:
         provider = (self._custom_llm_provider or self.provider or "").lower()
-        return provider == "deepseek" or self._looks_like_deepseek(self.provider, self.model_name, self.api_base)
-
-    def _should_sanitize_openai_messages(self) -> bool:
-        provider = (self._custom_llm_provider or self.provider or "").lower()
-        return provider in {"openai", "azure"}
-
-    def _sanitize_openai_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        sanitized: List[Dict[str, Any]] = []
-        for msg in messages or []:
-            new_msg = dict(msg)
-            content = msg.get("content")
-            if isinstance(content, list):
-                new_content: List[Dict[str, Any]] = []
-                for item in content:
-                    if isinstance(item, dict):
-                        itype = item.get("type")
-                        if itype == "text":
-                            text = item.get("text")
-                            if text is not None:
-                                new_content.append({"type": "text", "text": str(text)})
-                        elif itype == "image_url":
-                            url = None
-                            val = item.get("image_url")
-                            if isinstance(val, dict):
-                                url = val.get("url")
-                            elif isinstance(val, str):
-                                url = val
-                            if not url:
-                                url = item.get("url") or item.get("image")
-                            if url:
-                                new_content.append({"type": "image_url", "image_url": {"url": url}})
-                        else:
-                            text = item.get("text")
-                            if text is not None:
-                                new_content.append({"type": "text", "text": str(text)})
-                    elif item is not None:
-                        new_content.append({"type": "text", "text": str(item)})
-                if not new_content:
-                    fallback_text = stringify_message_content(content, image_placeholder=None)
-                    new_msg["content"] = fallback_text
-                else:
-                    new_msg["content"] = new_content
-            sanitized.append(new_msg)
-        return sanitized
-
-    def _format_tools(self, tools: Any) -> List[Dict[str, Any]]:
-        if not tools:
-            return []
-        if isinstance(tools, dict):
-            tools = [tools]
-        if not isinstance(tools, list):
-            return []
-        formatted = []
-        for tool in tools:
-            if not isinstance(tool, dict):
-                continue
-            if tool.get("type") == "function":
-                formatted.append(
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": tool["function"]["name"],
-                            "description": tool["function"].get("description", ""),
-                            "parameters": tool["function"].get("parameters", {"type": "object", "properties": {}}),
-                        },
-                    }
-                )
-            elif "name" in tool and "parameters" in tool:
-                formatted.append(
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": tool.get("name"),
-                            "description": tool.get("description", ""),
-                            "parameters": tool.get("parameters") or {"type": "object", "properties": {}},
-                        },
-                    }
-                )
-            else:
-                formatted.append(tool)
-        return formatted
-
-    def _normalize_sampling_params(self, params: Dict[str, Any], num_samples: Optional[int]) -> Dict[str, Any]:
-        sampling = {k: v for k, v in params.items() if v is not None}
-        normalized: Dict[str, Any] = {}
-
-        max_tokens = sampling.get("max_tokens") or sampling.get("max_new_tokens") or self._base_sampling.get("max_new_tokens")
-        normalized["max_tokens"] = self._prepare_max_tokens(max_tokens)
-        stop_sequences = sampling.get("stop_sequences") or sampling.get("stop") or self._base_sampling.get("stop")
-        if stop_sequences:
-            normalized["stop"] = stop_sequences
-
-        for key in ("temperature", "top_p", "presence_penalty", "frequency_penalty", "repetition_penalty", "logprobs", "top_k", "min_p", "seed"):
-            if sampling.get(key) is not None:
-                normalized[key] = sampling[key]
-            elif key in self._base_sampling and self._base_sampling[key] is not None:
-                normalized.setdefault(key, self._base_sampling[key])
-
-        normalized["n"] = sampling.get("n") or sampling.get("num_samples") or num_samples
-        return {k: v for k, v in normalized.items() if v is not None}
-
-    def _prepare_stop_sequences(self, stop: Any) -> List[str]:
-        if not stop:
-            return []
-        if isinstance(stop, str):
-            sequences = [stop]
-        elif isinstance(stop, list):
-            sequences = [s for s in stop if isinstance(s, str)]
-        else:
-            return []
-        if (self.provider or "").lower() == "anthropic":
-            sequences = [s for s in sequences if s and s.strip()]
-        return sequences
-
-    def _prepare_max_tokens(self, max_tokens: Any) -> Optional[int]:
-        if max_tokens is None:
-            return None
-        try:
-            max_tokens = int(max_tokens)
-        except (TypeError, ValueError):
-            return None
-        if max_tokens <= 0:
-            return None
-        if self._supports_reasoning_fn and self._supports_reasoning_fn(self.model_name):
-            target = max_tokens * 10
-            if self._max_context_length:
-                target = min(target, self._max_context_length)
-            logger.warning("Reasoning 模型 {} 调整 max_tokens 至 {}", self.model_name, target)
-            return target
-        if self._max_context_length:
-            return min(max_tokens, self._max_context_length)
-        return max_tokens
+        return provider == "deepseek" or looks_like_deepseek(self.provider, self.model_name, self.api_base)
 
     def _call_with_retries(self, func):
         last_exc: Exception | None = None
@@ -461,12 +501,41 @@ class LiteLLMBackend(EngineBackend):
                 logger.warning("LiteLLM 调用失败，重试 {}/{}，等待 {:.1f}s: {}", attempt + 1, self._max_retries, wait, exc)
                 time.sleep(wait)
         assert last_exc is not None
+        self._raise_classified_retry_failure(last_exc)
+        raise last_exc
+
+    async def _acall_with_retries(self, func):
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                return await func()
+            except Exception as exc:  # pragma: no cover - network/third-party errors
+                last_exc = exc
+                if self._is_non_retryable_error(exc):
+                    logger.debug("LiteLLM async call aborted without retry due to non-retryable error: {}", exc)
+                    break
+                if attempt == self._max_retries - 1:
+                    break
+                wait = min(64, self._retry_sleep * (self._retry_multiplier**attempt))
+                logger.warning(
+                    "LiteLLM async 调用失败，重试 {}/{}，等待 {:.1f}s: {}",
+                    attempt + 1,
+                    self._max_retries,
+                    wait,
+                    exc,
+                )
+                await asyncio.sleep(wait)
+        assert last_exc is not None
+        self._raise_classified_retry_failure(last_exc)
         raise last_exc
 
     @staticmethod
     def _is_non_retryable_error(exc: Exception) -> bool:
         """Return True when an error should bypass retry loops."""
 
+        status_code = status_code_from_error(exc)
+        if status_code in {400, 401, 403, 404, 422}:
+            return True
         message = str(exc).strip().lower()
         if not message:
             return False
@@ -475,224 +544,64 @@ class LiteLLMBackend(EngineBackend):
             "rolepool",
             "is shut down",
         )
-        return any(marker in message for marker in non_retryable_markers)
+        if any(marker in message for marker in non_retryable_markers):
+            return True
+        return False
 
-    @staticmethod
-    def _infer_provider(model_name: str | None) -> Optional[str]:
-        if not model_name:
-            return None
-        if model_name.startswith("deepseek/"):
-            return "deepseek"
-        if "/" in model_name:
-            return model_name.split("/")[0]
-        lower = model_name.lower()
-        if lower.startswith("deepseek"):
-            return "deepseek"
-        if lower.startswith("grok"):
-            return "grok"
-        if lower.startswith("moonshot"):
-            return "kimi"
-        if lower.startswith("azure:"):
-            return "azure"
-        return None
+    def _retry_owner(self, route_mode: str) -> str:
+        if route_mode == "router":
+            return "litellm_router"
+        if self._looks_like_litellm_gateway_endpoint():
+            return "litellm_gateway"
+        return "gage"
 
-    @staticmethod
-    def _looks_like_deepseek(provider: Optional[str], model: str, api_base: Optional[str] = None) -> bool:
-        target = (provider or "").lower()
-        model_lower = (model or "").lower()
-        base = (api_base or "").lower()
-        return target == "deepseek" or model_lower.startswith("deepseek") or "deepseek.com" in base
-
-    @staticmethod
-    def _looks_like_kimi(provider: Optional[str], model: str, api_base: Optional[str] = None) -> bool:
-        target = (provider or "").lower()
-        model_lower = (model or "").lower()
-        base = (api_base or "").lower()
-        return target in {"kimi", "moonshot"} or model_lower.startswith("moonshot") or "moonshot" in base or "kimi" in base
-
-    @staticmethod
-    def _looks_like_grok(provider: Optional[str], model: str, api_base: Optional[str] = None) -> bool:
-        target = (provider or "").lower()
-        model_lower = (model or "").lower()
-        base = (api_base or "").lower()
-        return target in {"grok", "xai"} or model_lower.startswith("grok") or "api.x.ai" in base or base.endswith("x.ai")
-
-    @staticmethod
-    def _looks_like_azure(provider: Optional[str], model: str, api_base: Optional[str] = None) -> bool:
-        target = (provider or "").lower()
-        model_lower = (model or "").lower()
-        base = (api_base or "").lower()
-        return target in {"azure", "azure_openai"} or "openai.azure.com" in base or "azure" in base or model_lower.startswith("azure:")
-
-    @staticmethod
-    def _normalize_custom_provider(provider: Optional[str]) -> Optional[str]:
-        if not provider:
-            return None
-        lower = provider.lower()
-        alias_map = {
-            "deepseek": "deepseek",
-            "kimi": "moonshot",
-            "moonshot": "moonshot",
-            "grok": "xai",
-            "xai": "xai",
-            "google": "gemini",
-            "gemini": "gemini",
-            "azure_openai": "azure",
-            "google_genai": "google",
-        }
-        return alias_map.get(lower, lower)
-
-    @staticmethod
-    def _content_piece(part: Any) -> str:
-        if isinstance(part, dict) and "text" in part:
-            return str(part["text"])
-        return str(part)
-
-    def _normalize_request_model(self, model_name: str) -> str:
-        """Return the provider-qualified model name when LiteLLM expects one."""
-
-        if self._looks_like_deepseek(self.provider, model_name, self.api_base) and "/" not in model_name:
-            return f"deepseek/{model_name}"
-        return model_name
-
-    def _resolve_api_key(self) -> Optional[str]:
-        """Resolve API credentials without leaking DeepSeek keys to other providers."""
-
-        candidates: List[Optional[str]] = [self._cfg.api_key]
-        if self._is_deepseek_target:
-            candidates.append(os.getenv("DEEPSEEK_API_KEY"))
-        candidates.extend(
-            [
-                os.getenv("LITELLM_API_KEY"),
-                os.getenv("OPENAI_API_KEY"),
-                os.getenv("XAI_API_KEY"),
-                os.getenv("GROK_API_KEY"),
-                os.getenv("AZURE_API_KEY"),
-                os.getenv("AZURE_OPENAI_API_KEY"),
-                os.getenv("KIMI_API_KEY"),
-                os.getenv("MOONSHOT_API_KEY"),
-            ]
+    def _looks_like_litellm_gateway_endpoint(self) -> bool:
+        if is_default_local_litellm_gateway(self.api_base or getattr(self._cfg, "api_base", None)):
+            return True
+        return is_explicit_litellm_gateway(
+            self.provider or getattr(self._cfg, "provider", None),
+            custom_llm_provider=self._custom_llm_provider or getattr(self._cfg, "custom_llm_provider", None),
+            topology_kind=self._vllm_topology_kind(),
         )
-        return next((candidate for candidate in candidates if candidate), None)
+
+    def _vllm_topology_kind(self) -> str | None:
+        topology = getattr(getattr(self._cfg, "vllm", None), "topology", None)
+        if topology is None:
+            return None
+        return getattr(topology, "kind", None)
+
+    @classmethod
+    def _raise_classified_retry_failure(cls, exc: Exception) -> None:
+        if cls._is_dependency_unavailable_error(exc):
+            raise LiteLLMBackendError(str(exc), DEPENDENCY_UNAVAILABLE) from exc
 
     @staticmethod
-    def _to_jsonable(obj: Any) -> Any:
-        """Best-effort convert litellm ModelResponse / stream chunks to JSON-safe objects."""
-        try:
-            if obj is None:
-                return None
-            if isinstance(obj, (str, int, float, bool)):
-                return obj
-            if isinstance(obj, dict):
-                return {k: LiteLLMBackend._to_jsonable(v) for k, v in obj.items()}
-            if isinstance(obj, list):
-                return [LiteLLMBackend._to_jsonable(v) for v in obj]
-            if hasattr(obj, "model_dump"):
-                return obj.model_dump()
-            if hasattr(obj, "__dict__"):
-                return {k: LiteLLMBackend._to_jsonable(v) for k, v in obj.__dict__.items()}
-            return str(obj)
-        except Exception:  # pragma: no cover - defensive
-            return str(obj)
-
-    @staticmethod
-    def _build_response_log_summary(
-        raw_response: Any,
-        *,
-        answer: str,
-        usage: Optional[Dict[str, Any]],
-        stream: bool,
-        request_model: Optional[str],
-        latency_ms: Optional[float],
-    ) -> Dict[str, Any]:
-        """Builds a non-sensitive response summary for logs.
-
-        Args:
-            raw_response: JSON-safe LiteLLM response payload.
-            answer: Extracted answer text returned to callers.
-            usage: Usage payload captured from the completion object.
-            stream: Whether the request used streaming mode.
-            request_model: Model name sent to LiteLLM for this request.
-            latency_ms: End-to-end request latency in milliseconds.
-
-        Returns:
-            A compact summary that excludes response content and tool payloads.
-        """
-
-        summary: Dict[str, Any] = {
-            "stream": stream,
-            "request_model": request_model,
-            "latency_ms": round(float(latency_ms), 3) if latency_ms is not None else None,
-            "answer_chars": len(answer or ""),
-            "response_type": type(raw_response).__name__,
-        }
-
-        if isinstance(raw_response, dict):
-            choices = raw_response.get("choices") or []
-            first_choice = choices[0] if choices else {}
-            summary.update(
-                {
-                    "response_model": raw_response.get("model"),
-                    "response_object": raw_response.get("object"),
-                    "choice_count": len(choices),
-                    "finish_reason": LiteLLMBackend._extract_finish_reason(first_choice),
-                    "has_tool_calls": LiteLLMBackend._choice_has_tool_calls(first_choice),
-                }
-            )
-        elif isinstance(raw_response, list):
-            first_chunk = next((chunk for chunk in raw_response if isinstance(chunk, dict)), {})
-            finish_choice = LiteLLMBackend._find_stream_finish_choice(raw_response)
-            summary.update(
-                {
-                    "response_object": first_chunk.get("object"),
-                    "response_model": first_chunk.get("model") or request_model,
-                    "chunk_count": len(raw_response),
-                    "finish_reason": LiteLLMBackend._extract_finish_reason(finish_choice),
-                    "has_tool_calls": LiteLLMBackend._choice_has_tool_calls(finish_choice),
-                }
-            )
-
-        resolved_usage = usage
-        if resolved_usage is None and isinstance(raw_response, dict):
-            resolved_usage = raw_response.get("usage")
-        if resolved_usage:
-            summary["usage"] = LiteLLMBackend._to_jsonable(resolved_usage)
-
-        return {key: value for key, value in summary.items() if value is not None}
-
-    @staticmethod
-    def _find_stream_finish_choice(raw_response: List[Any]) -> Dict[str, Any]:
-        """Returns the most informative stream choice for logging metadata."""
-
-        for chunk in reversed(raw_response):
-            if not isinstance(chunk, dict):
-                continue
-            choices = chunk.get("choices") or []
-            if choices:
-                return choices[0]
-        return {}
-
-    @staticmethod
-    def _extract_finish_reason(choice: Any) -> Optional[str]:
-        """Extracts finish_reason from a choice payload without touching content."""
-
-        if isinstance(choice, dict):
-            finish_reason = choice.get("finish_reason")
-            if finish_reason is not None:
-                return str(finish_reason)
-        return None
-
-    @staticmethod
-    def _choice_has_tool_calls(choice: Any) -> bool:
-        """Returns whether the choice contains tool-call metadata."""
-
-        if not isinstance(choice, dict):
+    def _is_dependency_unavailable_error(exc: Exception) -> bool:
+        status_code = status_code_from_error(exc)
+        if status_code in {408, 429, 500, 502, 503, 504}:
+            return True
+        message = str(exc).strip().lower()
+        if not message:
             return False
-        message = choice.get("message") or choice.get("delta") or {}
-        if not isinstance(message, dict):
-            return False
-        tool_calls = message.get("tool_calls")
-        return bool(tool_calls)
+        dependency_markers = (
+            "connection refused",
+            "connection error",
+            "failed to connect",
+            "failed to establish",
+            "max retries exceeded",
+            "name resolution",
+            "temporary failure in name resolution",
+            "timed out",
+            "timeout",
+            "connect timeout",
+            "read timeout",
+            "endpoint unavailable",
+            "service unavailable",
+            "bad gateway",
+            "gateway timeout",
+            "network is unreachable",
+        )
+        return any(marker in message for marker in dependency_markers)
 
     @staticmethod
     def _format_response_json(raw_response: Any) -> str:

--- a/src/gage_eval/role/model/config/litellm.py
+++ b/src/gage_eval/role/model/config/litellm.py
@@ -2,12 +2,171 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from importlib import import_module
+from typing import Any, Dict, Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from gage_eval.role.model.config.base import BackendConfigBase
 from gage_eval.role.model.config.generations import GenerationParameters
+
+
+MIN_LITELLM_VERSION = "1.63.8"
+MIN_VLLM_VERSION = "0.20.1"
+
+
+def assert_litellm_capabilities(
+    *,
+    require_router: bool = False,
+    require_async: bool = False,
+    require_function_calling: bool = False,
+    litellm_module: Any | None = None,
+) -> None:
+    """Fail fast when required LiteLLM SDK capabilities are unavailable."""
+
+    if litellm_module is None:
+        try:
+            litellm_module = import_module("litellm")
+        except ImportError as exc:
+            raise RuntimeError(
+                f"LiteLLM is not installed; install litellm>={MIN_LITELLM_VERSION} for the GAGE LiteLLM backend."
+            ) from exc
+
+    _require_callable(litellm_module, "completion", "LiteLLM completion")
+    if require_router:
+        _require_attribute(litellm_module, "Router", "LiteLLM Router")
+    if require_async:
+        _require_callable(litellm_module, "acompletion", "LiteLLM acompletion")
+    if require_function_calling:
+        _require_callable(litellm_module, "supports_function_calling", "LiteLLM supports_function_calling")
+
+
+def _require_attribute(module: Any, attribute: str, capability_name: str) -> None:
+    if getattr(module, attribute, None) is None:
+        raise RuntimeError(
+            f"{capability_name} is required by this LiteLLM backend feature. "
+            f"Install litellm>={MIN_LITELLM_VERSION} and verify the active environment is not using an older LiteLLM package."
+        )
+
+
+def _require_callable(module: Any, attribute: str, capability_name: str) -> None:
+    value = getattr(module, attribute, None)
+    if not callable(value):
+        raise RuntimeError(
+            f"{capability_name} is required by this LiteLLM backend feature. "
+            f"Install litellm>={MIN_LITELLM_VERSION} and verify the active environment is not using an older LiteLLM package."
+        )
+
+
+class LiteLLMRequestConfig(BackendConfigBase):
+    """LiteLLM completion parameters passed through from backend config."""
+
+    response_format: Dict[str, Any] | None = None
+    max_completion_tokens: int | None = Field(default=None, ge=1)
+    stream_options: Dict[str, Any] | None = None
+    parallel_tool_calls: bool | None = None
+    logit_bias: Dict[str, Any] | None = None
+    user: str | None = None
+    metadata: Dict[str, Any] | None = None
+    fallbacks: list[Dict[str, Any]] | None = None
+    context_window_fallback_dict: Dict[str, Any] | None = None
+    extra_body: Dict[str, Any] = Field(default_factory=dict)
+    drop_params: bool | None = None
+
+
+class LiteLLMRouterDeploymentConfig(BackendConfigBase):
+    """One LiteLLM Router deployment entry managed by the GAGE backend."""
+
+    model_name: str
+    litellm_params: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LiteLLMRouterSettingsConfig(BackendConfigBase):
+    """LiteLLM Router settings preserved for later router construction."""
+
+    routing_strategy: str | None = None
+    allowed_fails: int | None = Field(default=None, ge=0)
+    cooldown_time: float | None = Field(default=None, ge=0.0)
+    num_retries: int | None = Field(default=None, ge=0)
+
+
+class LiteLLMVLLMTopologyConfig(BackendConfigBase):
+    """vLLM endpoint topology metadata used for reporting and checks."""
+
+    language_model_only: bool | None = None
+    kind: str = "external_endpoint"
+
+
+class LiteLLMVLLMConfig(BackendConfigBase):
+    """vLLM profile metadata that does not participate in request building."""
+
+    topology: LiteLLMVLLMTopologyConfig = Field(default_factory=LiteLLMVLLMTopologyConfig)
+    reasoning_parser: str | None = None
+
+
+class LiteLLMThinkingPolicyConfig(BackendConfigBase):
+    """Policy for handling model thinking support and mismatch cases."""
+
+    capability: Literal["auto", "supported", "unsupported"] | None = None
+    on_unsupported: Literal["warn_and_continue", "fail_fast", "ignore"] | None = None
+    on_mismatch: Literal["warn_and_continue", "fail_fast", "ignore"] | None = None
+    record_effective_state: bool = False
+
+    @field_validator("capability", mode="before")
+    @classmethod
+    def _coerce_boolean_capability(cls, value: Any) -> Any:
+        if value is True:
+            return "supported"
+        if value is False:
+            return "unsupported"
+        return value
+
+
+class LiteLLMMultimodalPolicyConfig(BackendConfigBase):
+    """Policy for preserving multimodal content blocks through LiteLLM."""
+
+    preserve_blocks: bool = True
+    audio_url_mapping: str | None = None
+    default_audio_format: str | None = None
+    max_media_bytes: int | None = Field(default=None, ge=1)
+    fallback: Literal["fail", "preserve", "text"] = "fail"
+
+
+class LiteLLMToolExpectedServerFlagsConfig(BackendConfigBase):
+    """Expected server-side flags for vLLM tool-calling support."""
+
+    enable_auto_tool_choice: bool | None = None
+    tool_call_parser: str | None = None
+
+
+class LiteLLMToolCallingConfig(BackendConfigBase):
+    """Tool-calling capability expectations for LiteLLM-compatible servers."""
+
+    enabled: bool = False
+    tool_choice: Any | None = None
+    parallel_tool_calls: bool | None = None
+    auto_tool_choice: bool = False
+    require_server_parser: bool = False
+    expected_tool_parser: str | None = None
+    expected_server_flags: LiteLLMToolExpectedServerFlagsConfig = Field(
+        default_factory=LiteLLMToolExpectedServerFlagsConfig
+    )
+
+
+class ModelServerHealthConfig(BackendConfigBase):
+    """Health-check settings for experimental local model server startup."""
+
+    urls: list[str] = Field(default_factory=list)
+    timeout_seconds: float | None = Field(default=None, ge=0.0)
+    interval_seconds: float | None = Field(default=None, ge=0.0)
+
+
+class ModelServerLifecycleConfig(BackendConfigBase):
+    """Experimental command-mode local model server lifecycle config."""
+
+    enabled: bool = False
+    startup_command: str | None = None
+    health: ModelServerHealthConfig = Field(default_factory=ModelServerHealthConfig)
 
 
 class LiteLLMBackendConfig(BackendConfigBase):
@@ -34,3 +193,27 @@ class LiteLLMBackendConfig(BackendConfigBase):
     mock_api_key: Optional[str] = Field(default=None, description="本地/自建服务的密钥（可留空走环境变量）")
     mock_model: Optional[str] = Field(default=None, description="模拟调用时使用的模型名；缺省沿用 model")
     generation_parameters: GenerationParameters = Field(default_factory=GenerationParameters)
+    route_mode: Literal["direct", "router"] = "direct"
+    litellm_request: LiteLLMRequestConfig = Field(default_factory=LiteLLMRequestConfig)
+    model_list: list[LiteLLMRouterDeploymentConfig] = Field(default_factory=list)
+    router_settings: LiteLLMRouterSettingsConfig = Field(default_factory=LiteLLMRouterSettingsConfig)
+    vllm: LiteLLMVLLMConfig = Field(default_factory=LiteLLMVLLMConfig)
+    thinking_policy: LiteLLMThinkingPolicyConfig = Field(default_factory=LiteLLMThinkingPolicyConfig)
+    multimodal: LiteLLMMultimodalPolicyConfig = Field(default_factory=LiteLLMMultimodalPolicyConfig)
+    tool_calling: LiteLLMToolCallingConfig = Field(default_factory=LiteLLMToolCallingConfig)
+    model_server: ModelServerLifecycleConfig = Field(default_factory=ModelServerLifecycleConfig)
+
+    def resolved_route_mode(self) -> Literal["direct", "router"]:
+        if self.route_mode == "router":
+            return "router"
+        if self._field_was_explicitly_set("route_mode"):
+            return "direct"
+        if self.model_list:
+            return "router"
+        return "direct"
+
+    def _field_was_explicitly_set(self, field_name: str) -> bool:
+        fields_set = getattr(self, "model_fields_set", None)
+        if fields_set is None:
+            fields_set = getattr(self, "__fields_set__", set())
+        return field_name in fields_set

--- a/tests/integration/compatibility/backends/test_litellm_backend_offline_contracts.py
+++ b/tests/integration/compatibility/backends/test_litellm_backend_offline_contracts.py
@@ -1,0 +1,599 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from gage_eval.role.model.backends import wrap_backend
+from gage_eval.role.model.backends.litellm.errors import DEPENDENCY_UNAVAILABLE, LiteLLMBackendError
+from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
+
+pytestmark = [pytest.mark.compat, pytest.mark.fast]
+
+
+class _ProviderStatusError(RuntimeError):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _FakeRouter:
+    def __init__(
+        self,
+        *,
+        response: Any | None = None,
+        stream_chunks: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.init_kwargs = kwargs
+        self.calls: list[dict[str, Any]] = []
+        self.async_calls: list[dict[str, Any]] = []
+        self.response = response or {"choices": [{"message": {"content": "router-ok"}}]}
+        self.stream_chunks = stream_chunks or _stream_chunks("router")
+
+    def completion(self, **kwargs: Any) -> Any:
+        self.calls.append(dict(kwargs))
+        if kwargs.get("stream"):
+            return list(self.stream_chunks)
+        return self.response
+
+    async def acompletion(self, **kwargs: Any) -> Any:
+        self.async_calls.append(dict(kwargs))
+        if kwargs.get("stream"):
+            return _async_chunks(self.stream_chunks)
+        return self.response
+
+
+class _FakeLiteLLM(types.SimpleNamespace):
+    def __init__(
+        self,
+        *,
+        response: Any | None = None,
+        stream_chunks: list[dict[str, Any]] | None = None,
+        async_stream_chunks: list[dict[str, Any]] | None = None,
+        error: Exception | None = None,
+        supports_reasoning: bool = False,
+        supports_function_calling: bool | None = True,
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.async_calls: list[dict[str, Any]] = []
+        self.routers: list[_FakeRouter] = []
+        self.response = response or {"choices": [{"message": {"content": "direct-ok"}}]}
+        self.stream_chunks = stream_chunks or _stream_chunks("sync")
+        self.async_stream_chunks = async_stream_chunks or _stream_chunks("async")
+        self.error = error
+        self.supports_reasoning_value = supports_reasoning
+        self.supports_function_calling_value = supports_function_calling
+        self.drop_params = False
+        self.verbose = False
+
+        def _router_factory(**kwargs: Any) -> _FakeRouter:
+            router = _FakeRouter(response={"choices": [{"message": {"content": "router-ok"}}]}, **kwargs)
+            self.routers.append(router)
+            return router
+
+        super().__init__(Router=_router_factory)
+
+    def completion(self, **kwargs: Any) -> Any:
+        self.calls.append(dict(kwargs))
+        if self.error is not None:
+            raise self.error
+        if kwargs.get("stream"):
+            return list(self.stream_chunks)
+        return self.response
+
+    async def acompletion(self, **kwargs: Any) -> Any:
+        self.async_calls.append(dict(kwargs))
+        if self.error is not None:
+            raise self.error
+        if kwargs.get("stream"):
+            return _async_chunks(self.async_stream_chunks)
+        return self.response
+
+    def supports_reasoning(self, _model: str) -> bool:
+        return self.supports_reasoning_value
+
+    def supports_function_calling(self, _model: str) -> bool | None:
+        return self.supports_function_calling_value
+
+
+class _FakeProcess:
+    def __init__(self, returncode: int | None = None) -> None:
+        self.returncode = returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+async def _async_chunks(chunks: list[dict[str, Any]]) -> Any:
+    for chunk in chunks:
+        yield chunk
+
+
+def _stream_chunks(label: str) -> list[dict[str, Any]]:
+    return [
+        {"choices": [{"delta": {"content": f"{label}-"}}]},
+        {
+            "choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+        },
+    ]
+
+
+def _install_fake_litellm(monkeypatch: pytest.MonkeyPatch, fake: _FakeLiteLLM) -> _FakeLiteLLM:
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+    return fake
+
+
+def test_direct_hosted_vllm_completion_uses_direct_transport_and_gage_retry_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(monkeypatch, _FakeLiteLLM())
+
+    backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16, "temperature": 0.0},
+            "retry_sleep": 0.0,
+        }
+    )
+    result = backend.invoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "direct-ok"
+    assert len(fake_litellm.calls) == 1
+    call = fake_litellm.calls[0]
+    assert call["model"] == "hosted_vllm/Qwen/Qwen3.6-35B-A3B"
+    assert call["api_base"] == "http://127.0.0.1:8000/v1"
+    assert call["base_url"] == "http://127.0.0.1:8000/v1"
+    assert call["api_key"] == "dummy"
+    assert call["custom_llm_provider"] == "hosted_vllm"
+    assert call["max_tokens"] == 16
+    summary = result["metadata"]["observation_summary"]
+    assert summary["route_mode"] == "direct"
+    assert summary["retry_owner"] == "gage"
+
+
+def test_model_list_uses_litellm_router_and_strips_direct_transport_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(monkeypatch, _FakeLiteLLM())
+
+    backend = LiteLLMBackend(
+        {
+            "model": "qwen3-pool",
+            "api_base": "http://wrong-top-level.example/v1",
+            "api_key": "wrong-top-level-key",
+            "custom_llm_provider": "openai",
+            "extra_headers": {"X-Wrong": "top-level"},
+            "max_retries": 6,
+            "model_list": [
+                {
+                    "model_name": "qwen3-pool",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3-a",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                        "api_key": "deployment-key-a",
+                    },
+                }
+            ],
+            "router_settings": {"num_retries": 2},
+            "generation_parameters": {"max_new_tokens": 32, "temperature": 0.2},
+        }
+    )
+    result = backend.invoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "router-ok"
+    assert fake_litellm.calls == []
+    assert backend._max_retries == 1
+    router = fake_litellm.routers[0]
+    assert router.init_kwargs["model_list"][0]["litellm_params"]["api_base"] == "http://127.0.0.1:8000/v1"
+    assert router.init_kwargs["model_list"][0]["litellm_params"]["api_key"] == "deployment-key-a"
+    assert router.init_kwargs["num_retries"] == 2
+
+    call = router.calls[0]
+    assert call["model"] == "qwen3-pool"
+    assert call["messages"] == [{"role": "user", "content": "ping"}]
+    assert call["max_tokens"] == 32
+    assert call["temperature"] == 0.2
+    assert "api_base" not in call
+    assert "base_url" not in call
+    assert "api_key" not in call
+    assert "custom_llm_provider" not in call
+    assert "headers" not in call
+    assert result["metadata"]["observation_summary"]["retry_owner"] == "litellm_router"
+
+
+def test_external_gateway_uses_litellm_api_key_and_gateway_retry_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(monkeypatch, _FakeLiteLLM())
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("LITELLM_API_KEY", "gateway-key")
+
+    backend = LiteLLMBackend(
+        {
+            "model": "openai/Qwen/Qwen3.6-35B-A3B",
+            "api_base": "http://127.0.0.1:4000/v1",
+            "max_retries": 6,
+            "vllm": {"topology": {"kind": "external_gateway"}},
+            "generation_parameters": {"max_new_tokens": 16},
+            "retry_sleep": 0.0,
+        }
+    )
+    result = backend.invoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    call = fake_litellm.calls[0]
+    assert call["api_base"] == "http://127.0.0.1:4000/v1"
+    assert call["api_key"] == "gateway-key"
+    assert call["api_key"] != "openai-key"
+    assert backend._max_retries == 1
+    summary = result["metadata"]["observation_summary"]
+    assert summary["retry_owner"] == "litellm_gateway"
+    assert summary["topology"]["kind"] == "external_gateway"
+
+
+def test_thinking_controls_map_to_extra_body_and_gate_reasoning_token_expansion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(monkeypatch, _FakeLiteLLM(supports_reasoning=True))
+
+    disabled_backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/qwen3",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16, "thinking_mode": "disabled"},
+            "vllm": {"reasoning_parser": "qwen3"},
+        }
+    )
+    disabled_backend.invoke({"messages": [{"role": "user", "content": "no thinking"}]})
+
+    enabled_backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/qwen3",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16, "thinking_mode": "enabled"},
+            "vllm": {"reasoning_parser": "qwen3"},
+        }
+    )
+    enabled_backend.invoke({"messages": [{"role": "user", "content": "think"}]})
+
+    disabled_call, enabled_call = fake_litellm.calls
+    assert disabled_call["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+    assert disabled_call["max_tokens"] == 16
+    assert enabled_call["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+    assert enabled_call["max_tokens"] == 160
+
+
+def test_disabled_thinking_records_mismatch_when_response_contains_reasoning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(
+        monkeypatch,
+        _FakeLiteLLM(response={"choices": [{"message": {"content": "<think>hidden</think>\nvisible"}}]}),
+    )
+
+    backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/qwen3",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16, "thinking_mode": "disabled"},
+            "thinking_policy": {"on_mismatch": "warn_and_continue"},
+            "vllm": {"reasoning_parser": "qwen3"},
+        }
+    )
+    result = backend.invoke({"messages": [{"role": "user", "content": "answer only"}]})
+
+    assert len(fake_litellm.calls) == 1
+    assert result["answer"] == "visible"
+    assert result["reasoning_content"] == "hidden"
+    assert result["metadata"]["thinking_effective"] == "enabled"
+    assert result["metadata"]["thinking_mismatch"] == {
+        "expected": "disabled",
+        "observed": "enabled",
+        "error_type": "response_mismatch",
+        "reasoning_source": "think_tags",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_and_async_streaming_normalize_answer_usage_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sync_fake = _install_fake_litellm(monkeypatch, _FakeLiteLLM(stream_chunks=_stream_chunks("sync")))
+    sync_backend = LiteLLMBackend(
+        {
+            "model": "gpt-4o-mini",
+            "api_key": "openai-key",
+            "streaming": True,
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+    sync_result = sync_backend.invoke({"messages": [{"role": "user", "content": "stream"}]})
+
+    assert sync_result["answer"] == "sync-ok"
+    assert sync_result["usage"] == {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+    assert sync_result["finish_reason"] == "stop"
+    assert sync_result["metadata"]["observation_summary"]["stream"] is True
+    assert sync_fake.calls[0]["stream"] is True
+
+    async_fake = _install_fake_litellm(monkeypatch, _FakeLiteLLM(async_stream_chunks=_stream_chunks("async")))
+    async_backend = LiteLLMBackend(
+        {
+            "model": "gpt-4o-mini",
+            "api_key": "openai-key",
+            "streaming": True,
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+    async_result = await async_backend.ainvoke({"messages": [{"role": "user", "content": "stream"}]})
+
+    assert async_result["answer"] == "async-ok"
+    assert async_result["usage"] == {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+    assert async_result["metadata"]["observation_summary"]["stream"] is True
+    assert len(async_fake.async_calls) == 1
+    assert async_fake.calls == []
+    assert async_fake.async_calls[0]["stream"] is True
+
+
+def test_multimodal_payload_errors_fail_fast_before_litellm_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(monkeypatch, _FakeLiteLLM())
+
+    text_only_backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/text-only",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16},
+            "vllm": {"topology": {"language_model_only": True}},
+        }
+    )
+    with pytest.raises(ValueError, match="language_model_only.*error_type=unsupported_capability"):
+        text_only_backend.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "image_url", "image_url": {"url": "https://example.com/a.png"}}],
+                    }
+                ]
+            }
+        )
+
+    invalid_payload_backend = LiteLLMBackend(
+        {
+            "model": "gpt-4o-audio-preview",
+            "api_key": "openai-key",
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+    with pytest.raises(ValueError, match="invalid_media_payload"):
+        invalid_payload_backend.invoke(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_audio", "input_audio": {"data": "%%%!", "format": "wav"}}],
+                    }
+                ]
+            }
+        )
+
+    assert fake_litellm.calls == []
+
+
+def test_tool_calling_request_and_response_contract_preserves_invalid_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = _install_fake_litellm(
+        monkeypatch,
+        _FakeLiteLLM(
+            supports_function_calling=True,
+            response={
+                "choices": [
+                    {
+                        "finish_reason": "tool_calls",
+                        "message": {
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "call_good",
+                                    "type": "function",
+                                    "function": {"name": "lookup", "arguments": "{\"city\":\"Shanghai\"}"},
+                                },
+                                {
+                                    "id": "call_bad",
+                                    "type": "function",
+                                    "function": {"name": "lookup", "arguments": "{bad-json"},
+                                },
+                            ],
+                        },
+                    }
+                ]
+            },
+        ),
+    )
+
+    backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/qwen3-tools",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16},
+            "tool_calling": {
+                "enabled": True,
+                "auto_tool_choice": True,
+                "parallel_tool_calls": True,
+                "expected_server_flags": {
+                    "enable_auto_tool_choice": True,
+                    "tool_call_parser": "qwen3_xml",
+                },
+            },
+        }
+    )
+    result = backend.invoke(
+        {
+            "messages": [{"role": "user", "content": "weather"}],
+            "tools": [
+                {
+                    "name": "lookup",
+                    "description": "Lookup weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            ],
+        }
+    )
+
+    call = fake_litellm.calls[0]
+    assert call["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Lookup weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    assert call["tool_choice"] == "auto"
+    assert call["parallel_tool_calls"] is True
+    assert result["finish_reason"] == "tool_calls"
+    assert result["tool_calls"][0]["arguments"] == {"city": "Shanghai"}
+    assert result["tool_calls"][0]["raw_arguments"] == "{\"city\":\"Shanghai\"}"
+    assert result["tool_calls"][1]["arguments"] is None
+    assert result["tool_calls"][1]["raw_arguments"] == "{bad-json"
+    assert result["tool_calls"][1]["error"] == "invalid_tool_arguments"
+    assert result["metadata"]["observation_summary"]["tool_count"] == 1
+    assert result["metadata"]["observation_summary"]["tool_call_count"] == 2
+
+
+def test_error_classification_contracts_are_normalized_without_retrying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for status_code in (400, 422):
+        fake_litellm = _install_fake_litellm(
+            monkeypatch,
+            _FakeLiteLLM(error=_ProviderStatusError("provider rejected request", status_code)),
+        )
+        backend = LiteLLMBackend(
+            {
+                "model": "gpt-4o-mini",
+                "api_key": "openai-key",
+                "max_retries": 4,
+                "retry_sleep": 0.0,
+                "generation_parameters": {"max_new_tokens": 16},
+            }
+        )
+
+        result = wrap_backend(backend).invoke({"messages": [{"role": "user", "content": "bad request"}]})
+
+        assert len(fake_litellm.calls) == 1
+        assert result["status"] == status_code
+        assert result["backend"] == "LiteLLMBackend"
+
+    dependency_fake = _install_fake_litellm(monkeypatch, _FakeLiteLLM(error=RuntimeError("connection refused")))
+    dependency_backend = LiteLLMBackend(
+        {
+            "model": "gpt-4o-mini",
+            "api_key": "openai-key",
+            "max_retries": 2,
+            "retry_sleep": 0.0,
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+    dependency_result = wrap_backend(dependency_backend).invoke(
+        {"messages": [{"role": "user", "content": "dependency"}]}
+    )
+
+    assert len(dependency_fake.calls) == 2
+    assert dependency_result["error_type"] == DEPENDENCY_UNAVAILABLE
+    assert dependency_result["backend"] == "LiteLLMBackend"
+
+    unsupported_fake = _install_fake_litellm(
+        monkeypatch,
+        _FakeLiteLLM(supports_function_calling=False),
+    )
+    unsupported_backend = LiteLLMBackend(
+        {
+            "model": "gpt-4o-mini",
+            "api_key": "openai-key",
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+    unsupported_result = wrap_backend(unsupported_backend).invoke(
+        {
+            "messages": [{"role": "user", "content": "tools"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+        }
+    )
+
+    assert unsupported_fake.calls == []
+    assert unsupported_result["error_type"] == "unsupported_capability"
+    assert unsupported_result["backend"] == "LiteLLMBackend"
+
+
+def test_model_server_lifecycle_failures_are_dependency_unavailable_without_real_io() -> None:
+    timeout_clock = _FakeClock()
+    timeout_lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: _FakeProcess(),
+        urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("not ready")),
+        sleep=timeout_clock.sleep,
+        monotonic=timeout_clock.monotonic,
+    )
+    config = {
+        "enabled": True,
+        "startup_command": "vllm serve /models/qwen --port 8000",
+        "health": {
+            "urls": ["http://127.0.0.1:8000/health"],
+            "timeout_seconds": 0.25,
+            "interval_seconds": 0.1,
+        },
+    }
+
+    with pytest.raises(LiteLLMBackendError) as timeout_error:
+        timeout_lifecycle.ensure_ready(config)
+
+    assert timeout_error.value.error_type == DEPENDENCY_UNAVAILABLE
+    assert "timed out" in str(timeout_error.value).lower()
+    assert timeout_clock.sleeps
+
+    popen_lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bash unavailable")),
+        urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("not ready")),
+    )
+
+    with pytest.raises(LiteLLMBackendError) as popen_error:
+        popen_lifecycle.ensure_ready(config)
+
+    assert popen_error.value.error_type == DEPENDENCY_UNAVAILABLE
+    assert "bash unavailable" in str(popen_error.value)

--- a/tests/unit/role/model/test_backend_error_contract.py
+++ b/tests/unit/role/model/test_backend_error_contract.py
@@ -6,7 +6,8 @@ import pytest
 
 from gage_eval.role.adapters.dut_model import DUTModelAdapter
 from gage_eval.role.model.backends import wrap_backend
-from gage_eval.role.model.backends.base_backend import Backend
+from gage_eval.role.model.backends.base_backend import Backend, build_backend_error_result
+from gage_eval.role.model.backends.litellm.errors import LiteLLMBackendError
 
 
 class _ExplodingBackend(Backend):
@@ -49,6 +50,34 @@ def test_wrap_backend_normalizes_exceptions_into_error_payload() -> None:
         "error_type": "RuntimeError",
         "backend": "_ExplodingBackend",
     }
+
+
+@pytest.mark.fast
+def test_backend_error_result_prefers_machine_readable_error_type_attribute() -> None:
+    exc = RuntimeError("endpoint failed")
+    exc.error_type = "dependency_unavailable"  # type: ignore[attr-defined]
+
+    result = build_backend_error_result(exc, backend_name="LiteLLMBackend")
+
+    assert result["error_type"] == "dependency_unavailable"
+
+
+@pytest.mark.fast
+def test_backend_error_result_extracts_machine_readable_error_type_from_message() -> None:
+    exc = ValueError("tool_calling_not_supported (error_type=unsupported_capability)")
+
+    result = build_backend_error_result(exc, backend_name="LiteLLMBackend")
+
+    assert result["error_type"] == "unsupported_capability"
+
+
+@pytest.mark.fast
+def test_litellm_backend_error_preserves_exception_args_and_error_type() -> None:
+    exc = LiteLLMBackendError("endpoint failed", "dependency_unavailable")
+
+    assert exc.args == ("endpoint failed",)
+    assert exc.error_type == "dependency_unavailable"
+    assert "error_type=dependency_unavailable" in str(exc)
 
 
 @pytest.mark.fast

--- a/tests/unit/role/model/test_litellm_backend.py
+++ b/tests/unit/role/model/test_litellm_backend.py
@@ -1,25 +1,38 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import os
 import sys
+import threading
 import types
 import unittest
-from pathlib import Path
 from unittest import mock
 
-ROOT = Path(__file__).resolve().parents[4] / "src"
-if str(ROOT) not in sys.path:
-    sys.path.append(str(ROOT))
+import pytest
 
+from gage_eval.role.adapters.base import RoleAdapterState
+from gage_eval.role.adapters.dut_model import DUTModelAdapter
 from gage_eval.role.model.backends import wrap_backend
 from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
 
+pytestmark = pytest.mark.fast
+
 
 class _FakeLitellm(types.SimpleNamespace):
-    def __init__(self, *, raise_error: bool = False, response: object | None = None):
+    def __init__(
+        self,
+        *,
+        raise_error: bool = False,
+        response: object | None = None,
+        supports_function_calling: bool | None = None,
+        supports_function_calling_error: bool = False,
+    ):
         super().__init__()
         self.calls = []
+        self.async_calls = []
         self.raise_error = raise_error
         self.response = response or {"choices": [{"message": {"content": "pong-lite"}}]}
+        self.supports_function_calling_value = supports_function_calling
+        self.supports_function_calling_error = supports_function_calling_error
         self.drop_params = False
         self.verbose = False
         self.api_key = None
@@ -35,8 +48,115 @@ class _FakeLitellm(types.SimpleNamespace):
             raise RuntimeError("litellm failure")
         return self.response
 
+    async def acompletion(self, **kwargs):
+        payload = dict(kwargs)
+        payload["_drop_params"] = self.drop_params
+        payload["_verbose"] = self.verbose
+        self.async_calls.append(payload)
+        if self.raise_error:
+            raise RuntimeError("litellm failure")
+        return self.response
+
     def supports_reasoning(self, _model):
         return False
+
+    def supports_function_calling(self, _model):
+        if self.supports_function_calling_error:
+            raise RuntimeError("helper unavailable")
+        return self.supports_function_calling_value
+
+
+class _BlockingFakeLitellm(_FakeLitellm):
+    def __init__(self):
+        super().__init__()
+        self._all_entered = threading.Event()
+        self._release = threading.Event()
+        self._condition = threading.Condition()
+        self._entered_count = 0
+
+    def completion(self, **kwargs):
+        payload = dict(kwargs)
+        payload["_drop_params"] = self.drop_params
+        payload["_verbose"] = self.verbose
+        with self._condition:
+            self.calls.append(payload)
+            self._entered_count += 1
+            if self._entered_count == 2:
+                self._all_entered.set()
+
+        if not self._release.wait(timeout=2.0):
+            raise TimeoutError("test did not release fake LiteLLM completion")
+        return self.response
+
+    def wait_until_two_calls_entered(self) -> bool:
+        return self._all_entered.wait(timeout=1.0)
+
+    def release_all(self) -> None:
+        self._release.set()
+
+
+class _AsyncStreamingFakeLitellm(_FakeLitellm):
+    def __init__(self, *, stream_response=None):
+        super().__init__()
+        self.stream_response = stream_response
+        self.used_async_stream = False
+
+    async def acompletion(self, **kwargs):
+        self.async_calls.append(dict(kwargs))
+        if kwargs.get("stream"):
+            self.used_async_stream = True
+            if self.stream_response is not None:
+                return self.stream_response
+
+            async def _chunks():
+                yield {"choices": [{"delta": {"content": "hello "}}]}
+                yield {"choices": [{"delta": {"content": "async"}, "finish_reason": "stop"}]}
+
+            return _chunks()
+        return await super().acompletion(**kwargs)
+
+
+class _AsyncRouter:
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.calls = []
+        self.async_calls = []
+
+    def completion(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "router-sync"}}]}
+
+    async def acompletion(self, **kwargs):
+        self.async_calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "router-async"}}]}
+
+
+class _LegacyRouterWithoutAsync:
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.calls = []
+
+    def completion(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "router-sync"}}]}
+
+
+class _RouterFakeLitellm(_FakeLitellm):
+    def __init__(self, router_cls):
+        super().__init__()
+        self.Router = router_cls
+
+
+class _RetryAsyncFakeLitellm(_FakeLitellm):
+    def __init__(self, *, failures: list[Exception], response: object | None = None):
+        super().__init__(response=response or {"choices": [{"message": {"content": "retry-ok"}}]})
+        self.failures = list(failures)
+
+    async def acompletion(self, **kwargs):
+        self.async_calls.append(dict(kwargs))
+        if self.failures:
+            raise self.failures.pop(0)
+        return self.response
 
 
 class LiteLLMBackendTests(unittest.TestCase):
@@ -85,7 +205,7 @@ class LiteLLMBackendTests(unittest.TestCase):
         self.assertEqual(fake_litellm.drop_params, "keep-drop")
         self.assertEqual(fake_litellm.verbose, "keep-verbose")
 
-    def test_litellm_backend_restores_module_flags_after_request(self):
+    def test_litellm_backend_keeps_drop_params_request_scoped_and_does_not_mutate_verbose(self):
         fake_litellm = _FakeLitellm()
         fake_litellm.drop_params = "persist-drop"
         fake_litellm.verbose = "persist-verbose"
@@ -93,10 +213,30 @@ class LiteLLMBackendTests(unittest.TestCase):
             backend = LiteLLMBackend({"model": "gpt-4o-mini", "verbose": True})
             backend.generate({"messages": [{"role": "user", "content": "ping"}]})
 
-        self.assertEqual(fake_litellm.calls[0]["_drop_params"], True)
-        self.assertEqual(fake_litellm.calls[0]["_verbose"], True)
+        self.assertEqual(fake_litellm.calls[0]["drop_params"], True)
+        self.assertEqual(fake_litellm.calls[0]["_drop_params"], "persist-drop")
+        self.assertEqual(fake_litellm.calls[0]["_verbose"], "persist-verbose")
         self.assertEqual(fake_litellm.drop_params, "persist-drop")
         self.assertEqual(fake_litellm.verbose, "persist-verbose")
+
+    def test_litellm_direct_calls_are_not_serialized_by_backend_lock(self):
+        fake_litellm = _BlockingFakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend({"model": "gpt-4o-mini", "retry_sleep": 0.0})
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [
+                    pool.submit(backend.generate, {"messages": [{"role": "user", "content": "ping-a"}]}),
+                    pool.submit(backend.generate, {"messages": [{"role": "user", "content": "ping-b"}]}),
+                ]
+                try:
+                    self.assertTrue(fake_litellm.wait_until_two_calls_entered())
+                finally:
+                    fake_litellm.release_all()
+                results = [future.result(timeout=2.0) for future in futures]
+
+        self.assertEqual([result["answer"] for result in results], ["pong-lite", "pong-lite"])
+        self.assertEqual(len(fake_litellm.calls), 2)
+        self.assertTrue(all(call["drop_params"] is True for call in fake_litellm.calls))
 
     def test_litellm_backend_merges_sampling_and_headers(self):
         fake_litellm = _FakeLitellm()
@@ -122,6 +262,49 @@ class LiteLLMBackendTests(unittest.TestCase):
         self.assertEqual(call["max_tokens"], 8)
         self.assertEqual(call["stop"], ["END"])
         self.assertEqual(call["headers"]["X-Test"], "1")
+
+    def test_litellm_request_extra_body_uses_request_scoped_drop_params(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "hosted_vllm/demo-model",
+                    "api_key": "dummy",
+                    "generation_parameters": {"max_new_tokens": 16},
+                    "litellm_request": {
+                        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+                    },
+                }
+            )
+            result = backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+
+        self.assertEqual(result["answer"], "pong-lite")
+        call = fake_litellm.calls[0]
+        self.assertEqual(call["extra_body"], {"chat_template_kwargs": {"enable_thinking": False}})
+        self.assertIs(call["drop_params"], True)
+        self.assertNotIn("response_format", call)
+
+    def test_litellm_request_response_format_is_forwarded_only_when_configured(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            default_backend = LiteLLMBackend(
+                {
+                    "model": "gpt-4o-mini",
+                    "generation_parameters": {"max_new_tokens": 16},
+                }
+            )
+            configured_backend = LiteLLMBackend(
+                {
+                    "model": "gpt-4o-mini",
+                    "generation_parameters": {"max_new_tokens": 16},
+                    "litellm_request": {"response_format": {"type": "json_object"}},
+                }
+            )
+            default_backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+            configured_backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+
+        self.assertNotIn("response_format", fake_litellm.calls[0])
+        self.assertEqual(fake_litellm.calls[1]["response_format"], {"type": "json_object"})
 
     def test_grok_defaults_to_xai_base(self):
         fake_litellm = _FakeLitellm()
@@ -185,7 +368,8 @@ class LiteLLMBackendTests(unittest.TestCase):
 
         self.assertEqual(result["error"], "litellm failure")
         self.assertEqual(result["backend"], "LiteLLMBackend")
-        self.assertEqual(len(fake_litellm.calls), 2)
+        self.assertEqual(len(fake_litellm.async_calls), 2)
+        self.assertEqual(fake_litellm.calls, [])
 
     def test_azure_easy_config_fills_base_and_version(self):
         fake_litellm = _FakeLitellm()
@@ -281,6 +465,91 @@ class LiteLLMBackendTests(unittest.TestCase):
         self.assertEqual(call["messages"][0]["content"][1]["type"], "image_url")
         self.assertEqual(call["messages"][0]["content"][1]["image_url"]["url"], "https://example.com/image.png")
 
+    def test_openai_multimodal_messages_keep_audio_url_blocks(self):
+        fake_litellm = _FakeLitellm()
+        audio_url = "data:audio/wav;base64,QUJDRA=="
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "gpt-4o-mini",
+                    "api_key": "openai-key",
+                    "generation_parameters": {"max_new_tokens": 16},
+                }
+            )
+            prepared = backend.prepare_inputs(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "Transcribe this."},
+                                {"type": "audio_url", "audio_url": {"url": audio_url}},
+                            ],
+                        }
+                    ]
+                }
+            )
+            result = backend.generate(prepared)
+
+        self.assertEqual(result["answer"], "pong-lite")
+        call = fake_litellm.calls[0]
+        self.assertEqual(call["messages"][0]["content"][1], {"type": "audio_url", "audio_url": {"url": audio_url}})
+
+    def test_language_model_only_rejects_multimodal_before_litellm_call(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "hosted_vllm/text-only",
+                    "api_key": "dummy",
+                    "generation_parameters": {"max_new_tokens": 16},
+                    "vllm": {"topology": {"language_model_only": True}},
+                }
+            )
+            with self.assertRaisesRegex(ValueError, "language_model_only"):
+                backend.generate(
+                    {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+                                ],
+                            }
+                        ]
+                    }
+                )
+
+        self.assertEqual(fake_litellm.calls, [])
+
+    def test_language_model_only_allows_text_only_list_content(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "hosted_vllm/text-only",
+                    "api_key": "dummy",
+                    "generation_parameters": {"max_new_tokens": 16},
+                    "vllm": {"topology": {"language_model_only": True}},
+                }
+            )
+            result = backend.generate(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "hello"},
+                            ],
+                        }
+                    ]
+                }
+            )
+
+        self.assertEqual(result["answer"], "pong-lite")
+        self.assertEqual(len(fake_litellm.calls), 1)
+        self.assertEqual(fake_litellm.calls[0]["messages"][0]["content"], [{"type": "text", "text": "hello"}])
+
     def test_non_deepseek_target_does_not_use_deepseek_api_key(self):
         """Non-DeepSeek targets should ignore the DeepSeek-specific API key."""
 
@@ -305,15 +574,39 @@ class LiteLLMBackendTests(unittest.TestCase):
         call = fake_litellm.calls[0]
         self.assertEqual(call["api_key"], "openai-key")
 
-    def test_thinking_mode_disabled_injects_enable_thinking_false(self):
-        """Thinking mode 'disabled' should inject enable_thinking=False into litellm kwargs."""
+    def test_mock_fields_are_mapped_with_deprecation_warning(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}), mock.patch(
+            "gage_eval.role.model.backends.litellm_backend.logger.warning"
+        ) as warning:
+            backend = LiteLLMBackend(
+                {
+                    "mock_api_base": "http://127.0.0.1:8000/v1",
+                    "mock_api_key": "mock-key",
+                    "mock_model": "hosted_vllm/mock-qwen",
+                    "generation_parameters": {"max_new_tokens": 16},
+                }
+            )
+            result = backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+
+        self.assertEqual(result["answer"], "pong-lite")
+        call = fake_litellm.calls[0]
+        self.assertEqual(call["model"], "hosted_vllm/mock-qwen")
+        self.assertEqual(call["api_base"], "http://127.0.0.1:8000/v1")
+        self.assertEqual(call["api_key"], "mock-key")
+        warning_messages = [str(args[0]) for args, _kwargs in warning.call_args_list]
+        self.assertTrue(any("mock_api_base" in message and "deprecated" in message for message in warning_messages))
+
+    def test_thinking_mode_disabled_uses_vllm_extra_body(self):
+        """Thinking mode 'disabled' should use vLLM chat template kwargs, not a top-level kwarg."""
         fake_litellm = _FakeLitellm()
         with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
             backend = LiteLLMBackend(
                 {
-                    "model": "qwen3-32b",
+                    "model": "hosted_vllm/qwen3-32b",
                     "thinking_mode": "disabled",
                     "generation_parameters": {"max_new_tokens": 16},
+                    "vllm": {"reasoning_parser": "qwen3"},
                 }
             )
             result = backend.generate(
@@ -322,18 +615,19 @@ class LiteLLMBackendTests(unittest.TestCase):
 
         self.assertEqual(result["answer"], "pong-lite")
         call = fake_litellm.calls[0]
-        self.assertIn("enable_thinking", call)
-        self.assertFalse(call["enable_thinking"])
+        self.assertNotIn("enable_thinking", call)
+        self.assertFalse(call["extra_body"]["chat_template_kwargs"]["enable_thinking"])
 
-    def test_thinking_mode_enabled_injects_enable_thinking_true(self):
-        """Thinking mode 'enabled' should inject enable_thinking=True into litellm kwargs."""
+    def test_thinking_mode_enabled_uses_vllm_extra_body(self):
+        """Thinking mode 'enabled' should use vLLM chat template kwargs, not a top-level kwarg."""
         fake_litellm = _FakeLitellm()
         with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
             backend = LiteLLMBackend(
                 {
-                    "model": "qwen3-32b",
+                    "model": "hosted_vllm/qwen3-32b",
                     "thinking_mode": "enabled",
                     "generation_parameters": {"max_new_tokens": 16},
+                    "vllm": {"reasoning_parser": "qwen3"},
                 }
             )
             result = backend.generate(
@@ -342,8 +636,57 @@ class LiteLLMBackendTests(unittest.TestCase):
 
         self.assertEqual(result["answer"], "pong-lite")
         call = fake_litellm.calls[0]
-        self.assertIn("enable_thinking", call)
-        self.assertTrue(call["enable_thinking"])
+        self.assertNotIn("enable_thinking", call)
+        self.assertTrue(call["extra_body"]["chat_template_kwargs"]["enable_thinking"])
+
+    def test_top_level_thinking_mode_overrides_generation_parameters_after_prepare_inputs(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "hosted_vllm/qwen3-32b",
+                    "thinking_mode": "disabled",
+                    "generation_parameters": {
+                        "max_new_tokens": 16,
+                        "thinking_mode": "enabled",
+                    },
+                    "vllm": {"reasoning_parser": "qwen3"},
+                }
+            )
+            prepared = backend.prepare_inputs({"messages": [{"role": "user", "content": "solve 2+2"}]})
+            result = backend.generate(prepared)
+
+        self.assertEqual(result["answer"], "pong-lite")
+        call = fake_litellm.calls[0]
+        self.assertNotIn("enable_thinking", call)
+        self.assertFalse(call["extra_body"]["chat_template_kwargs"]["enable_thinking"])
+
+    def test_payload_thinking_mode_overrides_top_level_after_prepare_inputs(self):
+        fake_litellm = _FakeLitellm()
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "hosted_vllm/qwen3-32b",
+                    "thinking_mode": "disabled",
+                    "generation_parameters": {
+                        "max_new_tokens": 16,
+                        "thinking_mode": "enabled",
+                    },
+                    "vllm": {"reasoning_parser": "qwen3"},
+                }
+            )
+            prepared = backend.prepare_inputs(
+                {
+                    "messages": [{"role": "user", "content": "solve 2+2"}],
+                    "sampling_params": {"thinking_mode": "enabled"},
+                }
+            )
+            result = backend.generate(prepared)
+
+        self.assertEqual(result["answer"], "pong-lite")
+        call = fake_litellm.calls[0]
+        self.assertNotIn("enable_thinking", call)
+        self.assertTrue(call["extra_body"]["chat_template_kwargs"]["enable_thinking"])
 
     def test_reasoning_effort_forwarded_in_kwargs(self):
         """reasoning_effort from generation_parameters should be forwarded to litellm."""
@@ -373,7 +716,7 @@ class LiteLLMBackendTests(unittest.TestCase):
                     "generation_parameters": {"max_new_tokens": 16},
                 }
             )
-            result = backend.generate(
+            backend.generate(
                 {"messages": [{"role": "user", "content": "ping"}], "sampling_params": {"max_new_tokens": 16}}
             )
 
@@ -410,6 +753,10 @@ class LiteLLMBackendTests(unittest.TestCase):
                 result = backend.generate({"messages": [{"role": "user", "content": "ping"}]})
 
         self.assertEqual(result["answer"], "super-secret-answer")
+        self.assertEqual(result["finish_reason"], "stop")
+        self.assertEqual(result["usage"], {"prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8})
+        self.assertEqual(result["tool_calls"][0]["id"], "tool-1")
+        self.assertTrue(result["metadata"]["observation_summary"]["has_tool_calls"])
         message, payload = mock_logger_info.call_args_list[-1].args
         self.assertEqual(message, "LiteLLM response summary: {}")
         self.assertNotIn("super-secret-answer", payload)
@@ -417,6 +764,268 @@ class LiteLLMBackendTests(unittest.TestCase):
         self.assertIn("\"answer_chars\": 19", payload)
         self.assertIn("\"has_tool_calls\": true", payload)
         self.assertIn("\"finish_reason\": \"stop\"", payload)
+
+    def test_tools_fail_fast_when_litellm_reports_function_calling_not_supported(self):
+        fake_litellm = _FakeLitellm(supports_function_calling=False)
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "gpt-4o-mini",
+                    "generation_parameters": {"max_new_tokens": 16},
+                }
+            )
+            with self.assertRaisesRegex(ValueError, "tool_calling_not_supported"):
+                backend.generate(
+                    {
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                    }
+                )
+
+        self.assertEqual(fake_litellm.calls, [])
+
+    def test_hosted_vllm_tools_with_declared_parser_ignore_false_function_calling_helper(self):
+        fake_litellm = _FakeLitellm(supports_function_calling=False)
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "hosted_vllm/demo-model",
+                    "api_key": "dummy",
+                    "generation_parameters": {"max_new_tokens": 16},
+                    "tool_calling": {
+                        "expected_server_flags": {
+                            "enable_auto_tool_choice": True,
+                            "tool_call_parser": "qwen3_xml",
+                        }
+                    },
+                }
+            )
+            result = backend.generate(
+                {
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                    "tool_choice": "auto",
+                }
+            )
+
+        self.assertEqual(result["answer"], "pong-lite")
+        self.assertEqual(fake_litellm.calls[0]["tool_choice"], "auto")
+        self.assertEqual(fake_litellm.calls[0]["tools"][0]["function"]["name"], "lookup")
+
+    def test_tools_call_litellm_when_function_calling_is_supported(self):
+        fake_litellm = _FakeLitellm(supports_function_calling=True)
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "gpt-4o-mini",
+                    "generation_parameters": {"max_new_tokens": 16},
+                }
+            )
+            result = backend.generate(
+                {
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                }
+            )
+
+        self.assertEqual(result["answer"], "pong-lite")
+        self.assertEqual(fake_litellm.calls[0]["tools"][0]["function"]["name"], "lookup")
+
+    def test_tools_are_allowed_when_function_calling_helper_fails_unknown(self):
+        fake_litellm = _FakeLitellm(supports_function_calling_error=True)
+        with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+            backend = LiteLLMBackend(
+                {
+                    "model": "gpt-4o-mini",
+                    "generation_parameters": {"max_new_tokens": 16},
+                }
+            )
+            result = backend.generate(
+                {
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                }
+            )
+
+        self.assertEqual(result["answer"], "pong-lite")
+        self.assertEqual(fake_litellm.calls[0]["tools"][0]["function"]["name"], "lookup")
+
+
+@pytest.mark.asyncio
+async def test_async_invoke_uses_litellm_acompletion_without_sync_completion():
+    fake_litellm = _FakeLitellm(response={"choices": [{"message": {"content": "async-ok"}}]})
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend({"model": "gpt-4o-mini", "generation_parameters": {"max_new_tokens": 16}})
+        result = await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "async-ok"
+    assert len(fake_litellm.async_calls) == 1
+    assert fake_litellm.calls == []
+    assert fake_litellm.async_calls[0]["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_uses_async_chunks_and_stream_normalizer():
+    fake_litellm = _AsyncStreamingFakeLitellm()
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend(
+            {
+                "model": "gpt-4o-mini",
+                "streaming": True,
+                "generation_parameters": {"max_new_tokens": 16},
+            }
+        )
+        result = await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "hello async"
+    assert result["finish_reason"] == "stop"
+    assert fake_litellm.used_async_stream is True
+    assert len(fake_litellm.async_calls) == 1
+    assert fake_litellm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_accepts_completion_like_mapping_without_losing_answer():
+    fake_litellm = _AsyncStreamingFakeLitellm(
+        stream_response={"choices": [{"message": {"content": "mapping-stream-ok"}, "finish_reason": "stop"}]}
+    )
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend(
+            {
+                "model": "gpt-4o-mini",
+                "streaming": True,
+                "generation_parameters": {"max_new_tokens": 16},
+            }
+        )
+        result = await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "mapping-stream-ok"
+    assert result["finish_reason"] == "stop"
+    assert len(fake_litellm.async_calls) == 1
+    assert fake_litellm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_router_mode_calls_router_acompletion():
+    fake_litellm = _RouterFakeLitellm(_AsyncRouter)
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend(
+            {
+                "model": "qwen3-group",
+                "model_list": [
+                    {
+                        "model_name": "qwen3-group",
+                        "litellm_params": {
+                            "model": "hosted_vllm/qwen3",
+                            "api_base": "http://127.0.0.1:8000/v1",
+                            "api_key": "dummy",
+                        },
+                    }
+                ],
+                "generation_parameters": {"max_new_tokens": 16},
+            }
+        )
+        result = await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "router-async"
+    assert fake_litellm.calls == []
+    assert backend._router.calls == []
+    assert len(backend._router.async_calls) == 1
+    assert backend._router.async_calls[0]["model"] == "qwen3-group"
+    assert "api_base" not in backend._router.async_calls[0]
+
+
+@pytest.mark.asyncio
+async def test_async_router_mode_requires_router_acompletion():
+    fake_litellm = _RouterFakeLitellm(_LegacyRouterWithoutAsync)
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend(
+            {
+                "model": "qwen3-group",
+                "model_list": [
+                    {
+                        "model_name": "qwen3-group",
+                        "litellm_params": {
+                            "model": "hosted_vllm/qwen3",
+                            "api_base": "http://127.0.0.1:8000/v1",
+                            "api_key": "dummy",
+                        },
+                    }
+                ],
+                "generation_parameters": {"max_new_tokens": 16},
+            }
+        )
+        with pytest.raises(RuntimeError, match="acompletion|async"):
+            await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+
+def test_wrap_backend_sync_invoke_uses_litellm_completion_not_acompletion():
+    fake_litellm = _FakeLitellm(response={"choices": [{"message": {"content": "sync-ok"}}]})
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend({"model": "gpt-4o-mini", "generation_parameters": {"max_new_tokens": 16}})
+        wrapped = wrap_backend(backend)
+        result = wrapped.invoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "sync-ok"
+    assert len(fake_litellm.calls) == 1
+    assert fake_litellm.async_calls == []
+
+
+def test_dut_model_adapter_sync_invoke_uses_litellm_completion_not_acompletion():
+    fake_litellm = _FakeLitellm(response={"choices": [{"message": {"content": "adapter-sync-ok"}}]})
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend({"model": "gpt-4o-mini", "generation_parameters": {"max_new_tokens": 16}})
+        adapter = DUTModelAdapter(
+            adapter_id="dut",
+            role_type="dut_model",
+            backend=backend,
+            capabilities=(),
+        )
+        result = adapter.invoke({"sample": {"id": "sample-1", "text": "hello"}}, RoleAdapterState())
+
+    assert result["answer"] == "adapter-sync-ok"
+    assert len(fake_litellm.calls) == 1
+    assert fake_litellm.async_calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_litellm_retries_until_success():
+    fake_litellm = _RetryAsyncFakeLitellm(failures=[RuntimeError("temporary-1"), RuntimeError("temporary-2")])
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend(
+            {
+                "model": "gpt-4o-mini",
+                "generation_parameters": {"max_new_tokens": 16},
+                "max_retries": 3,
+                "retry_sleep": 0.0,
+            }
+        )
+        result = await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "retry-ok"
+    assert len(fake_litellm.async_calls) == 3
+    assert fake_litellm.calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_litellm_non_retryable_shutdown_error_is_not_retried():
+    fake_litellm = _RetryAsyncFakeLitellm(
+        failures=[RuntimeError("cannot schedule new futures after shutdown")],
+    )
+    with mock.patch.dict(sys.modules, {"litellm": fake_litellm}):
+        backend = LiteLLMBackend(
+            {
+                "model": "gpt-4o-mini",
+                "generation_parameters": {"max_new_tokens": 16},
+                "max_retries": 3,
+                "retry_sleep": 0.0,
+            }
+        )
+        with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+            await backend.ainvoke({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert len(fake_litellm.async_calls) == 1
+    assert fake_litellm.calls == []
 
 
 if __name__ == "__main__":

--- a/tests/unit/role/model/test_litellm_backend_config.py
+++ b/tests/unit/role/model/test_litellm_backend_config.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from gage_eval.registry import registry
+from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+
+pytestmark = pytest.mark.fast
+
+
+def test_litellm_backend_registry_advertises_multimodal_modalities() -> None:
+    assert registry.get("backends", "litellm") is LiteLLMBackend
+    assert registry.entry("backends", "litellm").extra["modalities"] == ("text", "vision", "audio")
+
+
+def test_simplified_vllm_config_parses_as_direct_endpoint() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+        }
+    )
+
+    assert config.model == "hosted_vllm/Qwen/Qwen3.6-35B-A3B"
+    assert config.api_base == "http://127.0.0.1:8000/v1"
+    assert config.route_mode == "direct"
+    assert config.resolved_route_mode() == "direct"
+
+
+def test_vllm_topology_profile_fields_parse_without_affecting_route_mode() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "vllm": {
+                "topology": {
+                    "language_model_only": True,
+                    "kind": "single_node_single_gpu",
+                    "gpu_ids": [0],
+                },
+                "reasoning_parser": "qwen3",
+            },
+        }
+    )
+
+    assert config.resolved_route_mode() == "direct"
+    assert config.vllm.topology.language_model_only is True
+    assert config.vllm.topology.kind == "single_node_single_gpu"
+    assert config.vllm.topology.gpu_ids == [0]
+    assert config.vllm.reasoning_parser == "qwen3"
+
+
+def test_model_server_minimal_command_mode_parses_without_legacy_lifecycle_fields() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "model_server": {
+                "enabled": True,
+                "startup_command": "bash framework/0521/start_vllm_8gpu.sh",
+                "health": {
+                    "urls": [
+                        "http://127.0.0.1:8000/health",
+                        "http://127.0.0.1:8001/health",
+                    ],
+                    "timeout_seconds": 1800,
+                    "interval_seconds": 5,
+                },
+            },
+        }
+    )
+
+    assert config.model_server.enabled is True
+    assert config.model_server.startup_command == "bash framework/0521/start_vllm_8gpu.sh"
+    assert config.model_server.health.urls == [
+        "http://127.0.0.1:8000/health",
+        "http://127.0.0.1:8001/health",
+    ]
+    assert config.model_server.health.timeout_seconds == 1800
+    assert config.model_server.health.interval_seconds == 5
+    assert not hasattr(config.model_server, "kind")
+    assert not hasattr(config.model_server, "experimental")
+    assert not hasattr(config.model_server, "cwd")
+    assert not hasattr(config.model_server, "shutdown_policy")
+
+
+def test_thinking_and_multimodal_policy_fields_parse() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "thinking_policy": {
+                "capability": "auto",
+                "on_unsupported": "warn_and_continue",
+                "on_mismatch": "fail_fast",
+                "record_effective_state": True,
+            },
+            "multimodal": {
+                "preserve_blocks": True,
+                "audio_url_mapping": "input_audio",
+                "default_audio_format": "wav",
+                "max_media_bytes": 5242880,
+            },
+        }
+    )
+
+    assert config.thinking_policy.on_mismatch == "fail_fast"
+    assert config.thinking_policy.record_effective_state is True
+    assert config.multimodal.audio_url_mapping == "input_audio"
+    assert config.multimodal.default_audio_format == "wav"
+    assert config.multimodal.max_media_bytes == 5242880
+    assert config.multimodal.fallback == "fail"
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        (True, "supported"),
+        (False, "unsupported"),
+    ],
+)
+def test_thinking_policy_capability_accepts_design_boolean_shortcuts(
+    capability: bool,
+    expected: str,
+) -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "thinking_policy": {"capability": capability},
+        }
+    )
+
+    assert config.thinking_policy.capability == expected
+
+
+@pytest.mark.parametrize(
+    "policy_payload",
+    [
+        {"thinking_policy": {"capability": "automatic"}},
+        {"thinking_policy": {"on_unsupported": "warn"}},
+        {"thinking_policy": {"on_mismatch": "fail"}},
+        {"multimodal": {"fallback": "best_effort"}},
+    ],
+)
+def test_policy_strategy_fields_reject_unknown_values(policy_payload: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        LiteLLMBackendConfig.model_validate({"model": "hosted_vllm/local", **policy_payload})
+
+
+def test_route_mode_model_list_and_router_settings_parse_with_extra_router_fields() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "Qwen/Qwen3.6-35B-A3B",
+            "route_mode": "router",
+            "model_list": [
+                {
+                    "model_name": "Qwen/Qwen3.6-35B-A3B",
+                    "litellm_params": {
+                        "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                        "api_key": "dummy",
+                    },
+                    "rpm": 60,
+                }
+            ],
+            "router_settings": {
+                "routing_strategy": "least-busy",
+                "allowed_fails": 2,
+                "cooldown_time": 30,
+                "num_retries": 1,
+                "retry_after": 5,
+            },
+        }
+    )
+
+    assert config.route_mode == "router"
+    assert config.resolved_route_mode() == "router"
+    assert config.model_list[0].model_name == "Qwen/Qwen3.6-35B-A3B"
+    assert config.model_list[0].litellm_params["api_base"] == "http://127.0.0.1:8000/v1"
+    assert config.model_list[0].rpm == 60
+    assert config.router_settings.routing_strategy == "least-busy"
+    assert config.router_settings.retry_after == 5
+
+
+def test_model_list_implies_router_when_route_mode_is_not_explicit() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "Qwen/Qwen3.6-35B-A3B",
+            "model_list": [
+                {
+                    "model_name": "Qwen/Qwen3.6-35B-A3B",
+                    "litellm_params": {"model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B"},
+                }
+            ],
+        }
+    )
+
+    assert config.route_mode == "direct"
+    assert config.resolved_route_mode() == "router"
+
+
+def test_explicit_direct_route_mode_keeps_model_list_on_direct_path() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "Qwen/Qwen3.6-35B-A3B",
+            "route_mode": "direct",
+            "model_list": [
+                {
+                    "model_name": "Qwen/Qwen3.6-35B-A3B",
+                    "litellm_params": {"model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B"},
+                }
+            ],
+        }
+    )
+
+    assert config.route_mode == "direct"
+    assert config.resolved_route_mode() == "direct"
+
+
+def test_litellm_request_design_passthrough_fields_parse() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3.6-35B-A3B",
+            "litellm_request": {
+                "response_format": {"type": "json_object"},
+                "max_completion_tokens": 1024,
+                "stream_options": {"include_usage": True},
+                "parallel_tool_calls": False,
+                "logit_bias": {"42": -1},
+                "user": "eval-user",
+                "metadata": {"run_id": "run-001"},
+                "fallbacks": [{"model": "openai/fallback"}],
+                "context_window_fallback_dict": {"openai/large": "openai/small"},
+                "extra_body": {"top_k": 20},
+                "drop_params": False,
+            },
+        }
+    )
+
+    request = config.litellm_request
+    assert request.response_format == {"type": "json_object"}
+    assert request.max_completion_tokens == 1024
+    assert request.stream_options == {"include_usage": True}
+    assert request.parallel_tool_calls is False
+    assert request.logit_bias == {"42": -1}
+    assert request.user == "eval-user"
+    assert request.metadata == {"run_id": "run-001"}
+    assert request.fallbacks == [{"model": "openai/fallback"}]
+    assert request.context_window_fallback_dict == {"openai/large": "openai/small"}
+    assert request.extra_body == {"top_k": 20}
+    assert request.drop_params is False
+
+
+def test_tool_calling_design_fields_parse() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "hosted_vllm/Qwen/Qwen3-Coder",
+            "tool_calling": {
+                "enabled": True,
+                "tool_choice": "auto",
+                "parallel_tool_calls": True,
+                "auto_tool_choice": True,
+                "require_server_parser": True,
+                "expected_server_flags": {
+                    "enable_auto_tool_choice": True,
+                    "tool_call_parser": "qwen3_xml",
+                },
+            },
+        }
+    )
+
+    tool_calling = config.tool_calling
+    assert tool_calling.enabled is True
+    assert tool_calling.tool_choice == "auto"
+    assert tool_calling.parallel_tool_calls is True
+    assert tool_calling.auto_tool_choice is True
+    assert tool_calling.require_server_parser is True
+    assert tool_calling.expected_server_flags.enable_auto_tool_choice is True
+    assert tool_calling.expected_server_flags.tool_call_parser == "qwen3_xml"
+
+
+def test_legacy_litellm_fields_still_parse() -> None:
+    config = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "openai/local",
+            "streaming": True,
+            "custom_llm_provider": "lm_studio",
+            "mock_api_base": "http://127.0.0.1:1234/v1",
+            "mock_api_key": "test-key",
+            "mock_model": "local-model",
+        }
+    )
+
+    assert config.streaming is True
+    assert config.custom_llm_provider == "lm_studio"
+    assert config.mock_api_base == "http://127.0.0.1:1234/v1"
+    assert config.mock_api_key == "test-key"
+    assert config.mock_model == "local-model"

--- a/tests/unit/role/model/test_litellm_backend_retry.py
+++ b/tests/unit/role/model/test_litellm_backend_retry.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import builtins
+import sys
+
 import pytest
 
+from gage_eval.role.model.backends.litellm.errors import DEPENDENCY_UNAVAILABLE, LiteLLMBackendError
+from gage_eval.role.model.backends.litellm.policies import ToolCallPolicy
 from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
 
 
@@ -11,6 +16,12 @@ def _build_backend_for_retry_tests(*, max_retries: int) -> LiteLLMBackend:
     backend._retry_sleep = 0.0
     backend._retry_multiplier = 1.0
     return backend
+
+
+class _ProviderStatusError(RuntimeError):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 @pytest.mark.fast
@@ -43,3 +54,179 @@ def test_call_with_retries_retries_for_retryable_error() -> None:
         backend._call_with_retries(_call)
 
     assert attempts == 3
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+def test_call_with_retries_does_not_retry_provider_client_errors(status_code: int) -> None:
+    backend = _build_backend_for_retry_tests(max_retries=6)
+    attempts = 0
+
+    def _call() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise _ProviderStatusError("provider rejected request", status_code)
+
+    with pytest.raises(_ProviderStatusError, match="provider rejected request"):
+        backend._call_with_retries(_call)
+
+    assert attempts == 1
+
+
+@pytest.mark.fast
+def test_call_with_retries_classifies_endpoint_unavailable_after_retry_budget() -> None:
+    backend = _build_backend_for_retry_tests(max_retries=2)
+    attempts = 0
+
+    def _call() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("connection refused")
+
+    with pytest.raises(LiteLLMBackendError) as exc_info:
+        backend._call_with_retries(_call)
+
+    assert attempts == 2
+    assert exc_info.value.error_type == DEPENDENCY_UNAVAILABLE
+
+
+@pytest.mark.fast
+def test_litellm_import_failure_is_dependency_unavailable(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def _import(name, *args, **kwargs):
+        if name == "litellm":
+            raise ImportError("missing litellm")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+    with pytest.raises(LiteLLMBackendError) as exc_info:
+        LiteLLMBackend({"model": "gpt-4o-mini"})
+
+    assert exc_info.value.error_type == DEPENDENCY_UNAVAILABLE
+
+
+@pytest.mark.fast
+def test_router_mode_uses_router_retry_owner_without_backend_retry(monkeypatch) -> None:
+    from tests.unit.role.model.test_litellm_router_factory import FakeLiteLLM
+
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "qwen3-group",
+            "max_retries": 6,
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                    },
+                }
+            ],
+            "router_settings": {"num_retries": 2},
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "hello"}]})
+
+    assert backend._max_retries == 1
+    assert result["metadata"]["observation_summary"]["retry_owner"] == "litellm_router"
+
+
+@pytest.mark.fast
+def test_gateway_mode_uses_gateway_retry_owner_without_backend_retry(monkeypatch) -> None:
+    from tests.unit.role.model.test_litellm_router_factory import FakeLiteLLM
+
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("LITELLM_API_KEY", "gateway-key")
+
+    backend = LiteLLMBackend(
+        {
+            "model": "openai/qwen3-group",
+            "api_base": "http://127.0.0.1:4000/v1",
+            "max_retries": 6,
+            "vllm": {"topology": {"kind": "external_gateway"}},
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "hello"}]})
+
+    assert backend._max_retries == 1
+    assert result["metadata"]["observation_summary"]["retry_owner"] == "litellm_gateway"
+    assert fake_litellm.calls[0]["api_key"] == "gateway-key"
+
+
+@pytest.mark.fast
+def test_default_local_gateway_config_uses_gateway_retry_owner_without_openai_key_leak(monkeypatch) -> None:
+    from tests.unit.role.model.test_litellm_router_factory import FakeLiteLLM
+
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "openai/qwen3-group",
+            "api_base": "http://127.0.0.1:4000/v1",
+            "max_retries": 6,
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "hello"}]})
+
+    assert backend._max_retries == 1
+    assert result["metadata"]["observation_summary"]["retry_owner"] == "litellm_gateway"
+    assert fake_litellm.calls[0]["api_key"] == "dummy"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "api_base",
+    [
+        "https://api-gateway.company.com/v1",
+        "https://litellm-compatible.company.com/v1",
+    ],
+)
+def test_gateway_like_direct_endpoint_keeps_gage_retry_owner_without_explicit_profile(
+    monkeypatch,
+    api_base: str,
+) -> None:
+    from tests.unit.role.model.test_litellm_router_factory import FakeLiteLLM
+
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "openai/qwen3-group",
+            "api_base": api_base,
+            "max_retries": 6,
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "hello"}]})
+
+    assert backend._max_retries == 6
+    assert result["metadata"]["observation_summary"]["retry_owner"] == "gage"
+
+
+@pytest.mark.fast
+def test_tool_calling_unsupported_error_is_classified_as_unsupported_capability() -> None:
+    policy = ToolCallPolicy()
+
+    with pytest.raises(ValueError, match="error_type=unsupported_capability"):
+        policy.apply(
+            {},
+            {"tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}]},
+            supports_function_calling=False,
+        )

--- a/tests/unit/role/model/test_litellm_credential_resolver.py
+++ b/tests/unit/role/model/test_litellm_credential_resolver.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.credential_resolver import ProviderCredentialResolver
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+
+pytestmark = pytest.mark.fast
+
+
+def _resolve(config: dict[str, object], env: dict[str, str]) -> str | None:
+    cfg = LiteLLMBackendConfig.model_validate(config)
+    with mock.patch.dict("os.environ", env, clear=True):
+        return ProviderCredentialResolver(cfg).resolve()
+
+
+def test_non_openai_provider_does_not_use_openai_api_key() -> None:
+    assert _resolve({"provider": "deepseek", "model": "deepseek-chat"}, {"OPENAI_API_KEY": "openai-key"}) is None
+
+
+def test_known_provider_does_not_use_litellm_api_key_for_gateway_like_direct_host() -> None:
+    assert (
+        _resolve(
+            {
+                "provider": "deepseek",
+                "model": "deepseek-chat",
+                "api_base": "https://api-gateway.company.com/v1",
+            },
+            {"LITELLM_API_KEY": "gateway-key"},
+        )
+        is None
+    )
+
+
+def test_explicit_litellm_gateway_provider_can_use_litellm_api_key() -> None:
+    assert _resolve({"provider": "gateway", "model": "qwen3"}, {"LITELLM_API_KEY": "gateway-key"}) == "gateway-key"
+
+
+def test_external_gateway_topology_uses_litellm_api_key_before_openai_api_key() -> None:
+    assert (
+        _resolve(
+            {
+                "model": "openai/qwen3-group",
+                "vllm": {"topology": {"kind": "external_gateway"}},
+            },
+            {"OPENAI_API_KEY": "openai-key", "LITELLM_API_KEY": "gateway-key"},
+        )
+        == "gateway-key"
+    )
+
+
+def test_default_local_litellm_gateway_does_not_fall_back_to_openai_api_key() -> None:
+    assert (
+        _resolve(
+            {
+                "model": "openai/qwen3-group",
+                "api_base": "http://127.0.0.1:4000/v1",
+            },
+            {"OPENAI_API_KEY": "openai-key"},
+        )
+        == "dummy"
+    )
+
+
+def test_default_local_litellm_gateway_prefers_litellm_api_key() -> None:
+    assert (
+        _resolve(
+            {
+                "model": "openai/qwen3-group",
+                "api_base": "http://127.0.0.1:4000/v1",
+            },
+            {"OPENAI_API_KEY": "openai-key", "LITELLM_API_KEY": "gateway-key"},
+        )
+        == "gateway-key"
+    )
+
+
+@pytest.mark.parametrize(
+    ("config", "env", "expected"),
+    [
+        ({"provider": "deepseek", "model": "deepseek-chat"}, {"DEEPSEEK_API_KEY": "deepseek-key"}, "deepseek-key"),
+        ({"provider": "kimi", "model": "moonshot-v1-8k"}, {"KIMI_API_KEY": "kimi-key"}, "kimi-key"),
+        ({"provider": "kimi", "model": "moonshot-v1-8k"}, {"MOONSHOT_API_KEY": "moonshot-key"}, "moonshot-key"),
+        ({"provider": "grok", "model": "grok-2"}, {"XAI_API_KEY": "xai-key"}, "xai-key"),
+        ({"provider": "grok", "model": "grok-2"}, {"GROK_API_KEY": "grok-key"}, "grok-key"),
+        ({"provider": "azure", "model": "azure:gpt-4o"}, {"AZURE_API_KEY": "azure-key"}, "azure-key"),
+        (
+            {"provider": "azure", "model": "azure:gpt-4o"},
+            {"AZURE_OPENAI_API_KEY": "azure-openai-key"},
+            "azure-openai-key",
+        ),
+        ({"provider": "openai", "model": "gpt-4o-mini"}, {"OPENAI_API_KEY": "openai-key"}, "openai-key"),
+    ],
+)
+def test_provider_specific_env_precedence(config: dict[str, object], env: dict[str, str], expected: str) -> None:
+    assert _resolve(config, {**env, "LITELLM_API_KEY": "gateway-key", "OPENAI_API_KEY": "openai-key"}) == expected
+
+
+def test_explicit_api_key_has_highest_priority() -> None:
+    assert (
+        _resolve(
+            {"provider": "deepseek", "model": "deepseek-chat", "api_key": "explicit-key"},
+            {"DEEPSEEK_API_KEY": "deepseek-key"},
+        )
+        == "explicit-key"
+    )
+
+
+def test_hosted_vllm_without_key_uses_safe_dummy_key() -> None:
+    assert _resolve({"model": "hosted_vllm/qwen3", "api_base": "http://127.0.0.1:8000/v1"}, {}) == "dummy"

--- a/tests/unit/role/model/test_litellm_dependency_guard.py
+++ b/tests/unit/role/model/test_litellm_dependency_guard.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from gage_eval.role.model.config import litellm as litellm_config
+
+
+@pytest.mark.fast
+def test_litellm_capability_guard_reports_missing_router(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = types.SimpleNamespace(completion=lambda **kwargs: None)
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+
+    with pytest.raises(RuntimeError, match="LiteLLM Router"):
+        litellm_config.assert_litellm_capabilities(require_router=True)
+
+
+@pytest.mark.fast
+def test_litellm_capability_guard_reports_missing_acompletion(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = types.SimpleNamespace(completion=lambda **kwargs: None, Router=object)
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+
+    with pytest.raises(RuntimeError, match="LiteLLM acompletion"):
+        litellm_config.assert_litellm_capabilities(require_async=True)
+
+
+@pytest.mark.fast
+def test_litellm_capability_guard_reports_missing_function_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = types.SimpleNamespace(completion=lambda **kwargs: None, Router=object, acompletion=lambda **kwargs: None)
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+
+    with pytest.raises(RuntimeError, match="LiteLLM supports_function_calling"):
+        litellm_config.assert_litellm_capabilities(require_function_calling=True)
+
+
+@pytest.mark.io
+def test_litellm_and_vllm_requirements_match_design_baseline() -> None:
+    requirements = (Path(__file__).resolve().parents[4] / "requirements.txt").read_text(encoding="utf-8")
+
+    assert f"litellm>={litellm_config.MIN_LITELLM_VERSION}" in requirements
+    assert f"vllm>={litellm_config.MIN_VLLM_VERSION}" in requirements
+    assert "litellm>=1.36.0" not in requirements
+    assert "vllm>=0.4.0" not in requirements

--- a/tests/unit/role/model/test_litellm_message_normalizer.py
+++ b/tests/unit/role/model/test_litellm_message_normalizer.py
@@ -1,0 +1,309 @@
+import base64
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.message_normalizer import MultimodalMessageNormalizer
+from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+from gage_eval.role.model.config.litellm import LiteLLMMultimodalPolicyConfig
+
+
+pytestmark = pytest.mark.fast
+
+
+def _normalizer(**policy_kwargs):
+    return MultimodalMessageNormalizer(
+        LiteLLMMultimodalPolicyConfig(**policy_kwargs),
+    )
+
+
+def test_multimodal_normalizer_preserves_audio_url_block_by_default():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "transcribe"},
+                {"type": "audio_url", "audio_url": {"url": "file:///tmp/a.wav"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer().normalize(messages)
+
+    assert normalized[0]["content"][1] == {
+        "type": "audio_url",
+        "audio_url": {"url": "file:///tmp/a.wav"},
+    }
+
+
+def test_preserve_blocks_false_applies_fallback_to_supported_multimodal_blocks():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer(preserve_blocks=False, fallback="text").normalize(messages)
+
+    assert normalized[0]["content"] == [
+        {"type": "text", "text": "describe"},
+        {"type": "text", "text": "[unsupported multimodal block: image_url]"},
+    ]
+
+
+def test_preserve_blocks_false_with_fail_rejects_supported_multimodal_blocks():
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="error_type=unsupported_capability"):
+        _normalizer(preserve_blocks=False, fallback="fail").normalize(messages)
+
+
+def test_audio_url_mapping_to_input_audio_uses_data_url_mime_format():
+    payload = base64.b64encode(b"audio").decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{payload}"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer(audio_url_mapping="input_audio", default_audio_format="mp3").normalize(messages)
+
+    assert normalized[0]["content"] == [
+        {"type": "input_audio", "input_audio": {"data": payload, "format": "wav"}}
+    ]
+
+
+def test_audio_url_mapping_to_input_audio_uses_default_audio_format_when_missing():
+    payload = base64.b64encode(b"audio").decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio_url", "audio_url": {"url": f"data:audio;base64,{payload}"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer(audio_url_mapping="input_audio", default_audio_format="wav").normalize(messages)
+
+    assert normalized[0]["content"][0]["input_audio"] == {"data": payload, "format": "wav"}
+
+
+def test_audio_url_mapping_to_input_audio_uses_default_format_for_mime_less_data_url():
+    payload = base64.b64encode(b"audio").decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio_url", "audio_url": {"url": f"data:;base64,{payload}"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer(audio_url_mapping="input_audio", default_audio_format="wav").normalize(messages)
+
+    assert normalized[0]["content"][0]["input_audio"] == {"data": payload, "format": "wav"}
+
+
+def test_video_file_file_url_and_document_blocks_are_preserved_or_converted():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "video_url", "video_url": "file:///tmp/clip.mp4"},
+                {"type": "file", "file": {"file_id": "file-123", "filename": "a.pdf"}},
+                {"type": "file_url", "file_url": {"url": "https://example.com/b.pdf", "filename": "b.pdf"}},
+                {"type": "file_url", "file_url": "https://example.com/c.pdf"},
+                {"type": "document", "document": {"url": "https://example.com/doc.pdf"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer().normalize(messages)
+
+    assert normalized[0]["content"][0] == {"type": "video_url", "video_url": {"url": "file:///tmp/clip.mp4"}}
+    assert normalized[0]["content"][1] == {
+        "type": "file",
+        "file": {"file_id": "file-123", "filename": "a.pdf"},
+    }
+    assert normalized[0]["content"][2] == {
+        "type": "file",
+        "file": {"file_id": "https://example.com/b.pdf", "filename": "b.pdf"},
+    }
+    assert normalized[0]["content"][3] == {
+        "type": "file",
+        "file": {"file_id": "https://example.com/c.pdf"},
+    }
+    assert normalized[0]["content"][4] == {
+        "type": "document",
+        "document": {"url": "https://example.com/doc.pdf"},
+    }
+
+
+def test_document_source_block_is_preserved_as_official_source_shape():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "document", "source": {"type": "file", "file_id": "file-abc"}},
+            ],
+        }
+    ]
+
+    normalized = _normalizer().normalize(messages)
+
+    assert normalized[0]["content"] == [
+        {"type": "document", "source": {"type": "file", "file_id": "file-abc"}},
+    ]
+
+
+def test_unknown_block_fails_loudly_when_fallback_is_fail():
+    messages = [{"role": "user", "content": [{"type": "unsupported", "value": "x"}]}]
+
+    with pytest.raises(ValueError, match="unsupported_modality"):
+        _normalizer().normalize(messages)
+
+
+def test_provider_specific_unknown_block_requires_explicit_preserve_fallback():
+    messages = [{"role": "user", "content": [{"type": "unsupported", "value": "x"}]}]
+
+    normalized = _normalizer().normalize(messages, fallback="preserve")
+
+    assert normalized[0]["content"] == [{"type": "unsupported", "value": "x"}]
+
+
+def test_invalid_data_url_raises_invalid_media_payload_without_payload_echo():
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,@@not-base64@@"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        _normalizer(audio_url_mapping="input_audio").normalize(messages)
+
+    message = str(exc_info.value)
+    assert "invalid_media_payload" in message
+    assert "@@not-base64@@" not in message
+
+
+def test_oversized_data_url_raises_media_payload_too_large_without_payload_echo():
+    payload = base64.b64encode(b"abcd").decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{payload}"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        _normalizer(audio_url_mapping="input_audio", max_media_bytes=3).normalize(messages)
+
+    message = str(exc_info.value)
+    assert "media_payload_too_large" in message
+    assert payload not in message
+    assert "size=4" in message
+    assert "limit=3" in message
+
+
+def test_oversized_payload_fails_before_scanning_later_invalid_characters():
+    payload = ("A" * 64) + "@@invalid-tail@@"
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{payload}"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        _normalizer(audio_url_mapping="input_audio", max_media_bytes=3).normalize(messages)
+
+    message = str(exc_info.value)
+    assert "media_payload_too_large" in message
+    assert payload not in message
+    assert "@@invalid-tail@@" not in message
+
+
+def test_oversized_data_url_does_not_echo_long_mime_header():
+    long_mime = "audio/" + ("x" * 256)
+    header = f"data:{long_mime};base64"
+    payload = base64.b64encode(b"abcd").decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "audio_url", "audio_url": {"url": f"{header},{payload}"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        _normalizer(audio_url_mapping="input_audio", max_media_bytes=3).normalize(messages)
+
+    message = str(exc_info.value)
+    assert "media_payload_too_large" in message
+    assert long_mime not in message
+    assert header not in message
+    assert len(message) < 180
+
+
+def test_document_source_raw_base64_data_is_validated():
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "document", "source": {"type": "base64", "data": "@@bad-base64@@"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        _normalizer().normalize(messages)
+
+    message = str(exc_info.value)
+    assert "invalid_media_payload" in message
+    assert "@@bad-base64@@" not in message
+
+
+def test_document_source_raw_base64_size_limit_is_enforced_without_payload_echo():
+    payload = base64.b64encode(b"abcd").decode("ascii")
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "document", "source": {"type": "base64", "data": payload}}],
+        }
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        _normalizer(max_media_bytes=3).normalize(messages)
+
+    message = str(exc_info.value)
+    assert "media_payload_too_large" in message
+    assert payload not in message
+    assert "limit=3" in message
+
+
+def test_language_model_only_profile_rejects_multimodal_request():
+    profile = VLLMServiceProfile(
+        mode="direct",
+        model="hosted_vllm/text-only",
+        topology={"language_model_only": True},
+        language_model_only=True,
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}],
+        }
+    ]
+
+    with pytest.raises(ValueError, match="language_model_only"):
+        _normalizer().normalize(messages, profile=profile)

--- a/tests/unit/role/model/test_litellm_model_server_lifecycle.py
+++ b/tests/unit/role/model/test_litellm_model_server_lifecycle.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.errors import DEPENDENCY_UNAVAILABLE, LiteLLMBackendError
+from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+
+pytestmark = pytest.mark.fast
+
+
+class FakeProcess:
+    def __init__(self, returncode: int | None = None):
+        self.returncode = returncode
+        self.poll_count = 0
+
+    def poll(self):
+        self.poll_count += 1
+        return self.returncode
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+class FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def read(self):
+        return b"ok"
+
+
+class FakeLiteLLM(types.SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    def completion(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    def supports_reasoning(self, _model):
+        return False
+
+    def supports_function_calling(self, _model):
+        return True
+
+
+def lifecycle_config(**model_server_overrides: Any):
+    payload = {
+        "model": "hosted_vllm/qwen",
+        "api_base": "http://127.0.0.1:8000/v1",
+        "api_key": "dummy",
+        "model_server": {
+            "enabled": True,
+            "startup_command": "vllm serve /models/qwen --port 8000",
+            "health": {
+                "urls": ["http://127.0.0.1:8000/health"],
+                "timeout_seconds": 3,
+                "interval_seconds": 1,
+            },
+        },
+    }
+    payload["model_server"].update(model_server_overrides)
+    return LiteLLMBackendConfig.model_validate(payload).model_server
+
+
+def test_disabled_lifecycle_does_not_require_startup_command() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    started = []
+    lifecycle = ModelServerLifecycle(
+        popen=lambda command, **kwargs: started.append((command, kwargs)) or FakeProcess(),
+        urlopen=lambda *args, **kwargs: pytest.fail("disabled lifecycle must not probe health"),
+    )
+
+    state = lifecycle.ensure_ready(lifecycle_config(enabled=False, startup_command=None))
+
+    assert state.enabled is False
+    assert state.ready is True
+    assert state.started is False
+    assert started == []
+
+
+def test_already_healthy_skips_startup_command() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    started = []
+    probed_urls = []
+
+    def urlopen(request, timeout):
+        probed_urls.append(request.full_url)
+        return FakeResponse()
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda command, **kwargs: started.append((command, kwargs)) or FakeProcess(),
+        urlopen=urlopen,
+    )
+
+    state = lifecycle.ensure_ready(lifecycle_config())
+
+    assert state.ready is True
+    assert state.started is False
+    assert started == []
+    assert probed_urls == ["http://127.0.0.1:8000/health"]
+
+
+def test_startup_command_runs_with_bash_until_health_succeeds() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    clock = FakeClock()
+    started = []
+    attempts = {"count": 0}
+
+    def urlopen(_request, timeout):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise TimeoutError("not ready")
+        return FakeResponse()
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda command, **kwargs: started.append((command, kwargs)) or FakeProcess(),
+        urlopen=urlopen,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    state = lifecycle.ensure_ready(lifecycle_config())
+
+    assert state.ready is True
+    assert state.started is True
+    assert started[0][0] == ["bash", "-lc", "vllm serve /models/qwen --port 8000"]
+    assert "stdout" not in started[0][1]
+    assert "stderr" not in started[0][1]
+    assert attempts["count"] == 2
+
+
+def test_health_timeout_raises_dependency_unavailable() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    clock = FakeClock()
+    lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: FakeProcess(),
+        urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("not ready")),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    with pytest.raises(LiteLLMBackendError) as exc_info:
+        lifecycle.ensure_ready(lifecycle_config())
+
+    assert exc_info.value.error_type == DEPENDENCY_UNAVAILABLE
+    assert "timed out" in str(exc_info.value).lower()
+
+
+def test_zero_health_interval_is_clamped_to_positive_sleep() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    clock = FakeClock()
+    lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: FakeProcess(),
+        urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("not ready")),
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    with pytest.raises(LiteLLMBackendError) as exc_info:
+        lifecycle.ensure_ready(
+            lifecycle_config(
+                health={
+                    "urls": ["http://127.0.0.1:8000/health"],
+                    "timeout_seconds": 0.25,
+                    "interval_seconds": 0,
+                }
+            )
+        )
+
+    assert exc_info.value.error_type == DEPENDENCY_UNAVAILABLE
+    assert clock.sleeps
+    assert all(seconds > 0 for seconds in clock.sleeps)
+
+
+def test_multi_health_urls_must_all_be_healthy_before_skip() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    clock = FakeClock()
+    started = []
+    calls = []
+
+    def urlopen(request, timeout):
+        calls.append(request.full_url)
+        if request.full_url.endswith(":8001/health") and calls.count(request.full_url) == 1:
+            raise TimeoutError("second replica not ready")
+        return FakeResponse()
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda command, **kwargs: started.append(command) or FakeProcess(),
+        urlopen=urlopen,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    state = lifecycle.ensure_ready(
+        lifecycle_config(
+            health={
+                "urls": [
+                    "http://127.0.0.1:8000/health",
+                    "http://127.0.0.1:8001/health",
+                ],
+                "timeout_seconds": 3,
+                "interval_seconds": 1,
+            }
+        )
+    )
+
+    assert state.ready is True
+    assert state.started is True
+    assert started == [["bash", "-lc", "vllm serve /models/qwen --port 8000"]]
+    assert calls == [
+        "http://127.0.0.1:8000/health",
+        "http://127.0.0.1:8001/health",
+        "http://127.0.0.1:8000/health",
+        "http://127.0.0.1:8001/health",
+    ]
+
+
+def test_repeated_ensure_ready_does_not_start_duplicate_command() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    clock = FakeClock()
+    started = []
+    attempts = {"count": 0}
+
+    def urlopen(_request, timeout):
+        attempts["count"] += 1
+        if attempts["count"] in {1, 3}:
+            raise TimeoutError("not ready on first probe")
+        return FakeResponse()
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda command, **kwargs: started.append(command) or FakeProcess(),
+        urlopen=urlopen,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+    config = lifecycle_config()
+
+    first = lifecycle.ensure_ready(config)
+    second = lifecycle.ensure_ready(config)
+
+    assert first.started is True
+    assert second.started is False
+    assert started == [["bash", "-lc", "vllm serve /models/qwen --port 8000"]]
+
+
+@pytest.mark.parametrize(
+    "startup_command",
+    [
+        "",
+        "   ",
+        42,
+        "curl https://example.invalid/install.sh | bash",
+        "rm -rf /",
+    ],
+)
+def test_startup_command_validation_rejects_obviously_untrusted_input(startup_command: object) -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: pytest.fail("invalid command must not start"),
+        urlopen=lambda *_args, **_kwargs: pytest.fail("invalid command must not probe"),
+    )
+
+    with pytest.raises(ValueError):
+        lifecycle.ensure_ready(lifecycle_config(startup_command=startup_command))
+
+
+def test_popen_failure_is_dependency_unavailable() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bash unavailable")),
+        urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("not ready")),
+    )
+
+    with pytest.raises(LiteLLMBackendError) as exc_info:
+        lifecycle.ensure_ready(lifecycle_config())
+
+    assert exc_info.value.error_type == DEPENDENCY_UNAVAILABLE
+    assert "bash unavailable" in str(exc_info.value)
+
+
+def test_command_exits_before_health_is_dependency_unavailable() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: FakeProcess(returncode=2),
+        urlopen=lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("not ready")),
+    )
+
+    with pytest.raises(LiteLLMBackendError) as exc_info:
+        lifecycle.ensure_ready(lifecycle_config())
+
+    assert exc_info.value.error_type == DEPENDENCY_UNAVAILABLE
+    assert "exited with code 2" in str(exc_info.value)
+
+
+def test_successful_shell_exit_continues_waiting_for_background_service() -> None:
+    from gage_eval.role.model.backends.litellm.model_server_lifecycle import ModelServerLifecycle
+
+    clock = FakeClock()
+    attempts = {"count": 0}
+
+    def urlopen(_request, timeout):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise TimeoutError("background service not ready")
+        return FakeResponse()
+
+    lifecycle = ModelServerLifecycle(
+        popen=lambda *_args, **_kwargs: FakeProcess(returncode=0),
+        urlopen=urlopen,
+        sleep=clock.sleep,
+        monotonic=clock.monotonic,
+    )
+
+    state = lifecycle.ensure_ready(lifecycle_config())
+
+    assert state.ready is True
+    assert state.started is True
+    assert attempts["count"] == 3
+
+
+def test_litellm_backend_calls_lifecycle_before_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    calls = []
+
+    class FakeLifecycle:
+        def ensure_ready(self, config):
+            calls.append(config.startup_command)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "hosted_vllm/qwen",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "model_server": {
+                "enabled": True,
+                "startup_command": "vllm serve /models/qwen --port 8000",
+                "health": {"urls": ["http://127.0.0.1:8000/health"]},
+            },
+            "_model_server_lifecycle": FakeLifecycle(),
+        }
+    )
+
+    assert backend._litellm is fake_litellm
+    assert calls == ["vllm serve /models/qwen --port 8000"]
+    assert fake_litellm.calls == []
+
+
+def test_litellm_backend_disabled_lifecycle_has_no_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    calls = []
+
+    class FakeLifecycle:
+        def ensure_ready(self, config):
+            calls.append(config)
+
+    LiteLLMBackend(
+        {
+            "model": "hosted_vllm/qwen",
+            "api_base": "http://127.0.0.1:8000/v1",
+            "api_key": "dummy",
+            "model_server": {"enabled": False},
+            "_model_server_lifecycle": FakeLifecycle(),
+        }
+    )
+
+    assert calls == []
+    assert fake_litellm.calls == []

--- a/tests/unit/role/model/test_litellm_provider_detection.py
+++ b/tests/unit/role/model/test_litellm_provider_detection.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.provider_detection import (
+    infer_provider_from_model,
+    is_default_local_litellm_gateway,
+    is_explicit_litellm_gateway,
+    looks_like_azure,
+    looks_like_deepseek,
+    looks_like_grok,
+    looks_like_kimi,
+    normalize_custom_provider,
+    normalize_provider_name,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def test_infer_provider_from_model_preserves_backend_and_credential_resolver_modes() -> None:
+    assert infer_provider_from_model("deepseek-chat") == "deepseek"
+    assert infer_provider_from_model("hosted_vllm/qwen3") == "hosted_vllm"
+    assert infer_provider_from_model("gpt-4o-mini") is None
+    assert infer_provider_from_model("gpt-4o-mini", include_openai_family=True) == "openai"
+
+
+def test_provider_normalization_and_custom_provider_aliases_match_existing_contract() -> None:
+    assert normalize_provider_name("azure-openai") == "azure_openai"
+    assert normalize_custom_provider("kimi") == "moonshot"
+    assert normalize_custom_provider("grok") == "xai"
+    assert normalize_custom_provider("azure_openai") == "azure"
+
+
+def test_provider_family_detection_matches_existing_backend_heuristics() -> None:
+    assert looks_like_deepseek("openai", "deepseek-chat")
+    assert looks_like_deepseek(None, "chat", "https://api.deepseek.com")
+    assert looks_like_kimi(None, "moonshot-v1-8k")
+    assert looks_like_grok(None, "grok-2")
+    assert looks_like_azure(None, "azure:gpt-4o")
+
+
+def test_litellm_gateway_detection_requires_explicit_profile_or_default_local_port() -> None:
+    assert is_explicit_litellm_gateway(topology_kind="external_gateway")
+    assert is_default_local_litellm_gateway("http://127.0.0.1:4000/v1")
+    assert not is_default_local_litellm_gateway("https://api-gateway.company.com/v1")

--- a/tests/unit/role/model/test_litellm_request_builder.py
+++ b/tests/unit/role/model/test_litellm_request_builder.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.request_builder import (
+    LITELLM_REQUEST_PASSTHROUGH_FIELDS,
+    LiteLLMRequestBuilder,
+)
+from gage_eval.role.model.backends.litellm.policies import ToolCallPolicy
+from gage_eval.role.model.config.litellm import LiteLLMRequestConfig, LiteLLMToolCallingConfig
+
+pytestmark = pytest.mark.fast
+
+
+def _builder(**overrides: object) -> LiteLLMRequestBuilder:
+    params = {
+        "model_name": "hosted_vllm/demo-model",
+        "provider": "hosted_vllm",
+        "api_base": "http://127.0.0.1:8000/v1",
+        "api_key": "dummy",
+        "timeout": 30.0,
+        "headers": {"X-Test": "1"},
+        "custom_llm_provider": "hosted_vllm",
+        "base_sampling": {"max_new_tokens": 256, "temperature": 0.2},
+        "litellm_request": LiteLLMRequestConfig(),
+        "drop_params": True,
+    }
+    params.update(overrides)
+    return LiteLLMRequestBuilder(**params)
+
+
+def test_response_format_is_only_sent_when_configured() -> None:
+    kwargs, _ = _builder().build({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert "response_format" not in kwargs
+
+    request = LiteLLMRequestConfig(response_format={"type": "json_object"})
+    configured_kwargs, _ = _builder(litellm_request=request).build(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    )
+
+    assert configured_kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_extra_body_and_drop_params_are_request_level_kwargs() -> None:
+    request = LiteLLMRequestConfig(extra_body={"top_k": 20}, drop_params=False)
+
+    kwargs, _ = _builder(litellm_request=request, drop_params=True).build(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    )
+
+    assert kwargs["extra_body"] == {"top_k": 20}
+    assert kwargs["drop_params"] is False
+
+
+def test_litellm_request_overrides_generation_parameter_conflicts() -> None:
+    request = LiteLLMRequestConfig(
+        max_completion_tokens=128,
+        metadata={"source": "litellm_request"},
+        response_format={"type": "json_object"},
+    )
+
+    kwargs, _ = _builder(litellm_request=request).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "sampling_params": {
+                "max_completion_tokens": 64,
+                "metadata": {"source": "generation_parameters"},
+                "response_format": {"type": "text"},
+            },
+        }
+    )
+
+    assert kwargs["max_completion_tokens"] == 128
+    assert kwargs["metadata"] == {"source": "litellm_request"}
+    assert kwargs["response_format"] == {"type": "json_object"}
+
+
+def test_endpoint_api_base_raises_clear_error() -> None:
+    builder = _builder(api_base="http://127.0.0.1:8000/v1/chat/completions")
+
+    with pytest.raises(ValueError, match="api_base.*base URL.*\\/v1.*not.*endpoint.*error_type=invalid_request"):
+        builder.build({"messages": [{"role": "user", "content": "ping"}]})
+
+
+def test_custom_llm_provider_is_forwarded() -> None:
+    kwargs, _ = _builder(custom_llm_provider="hosted_vllm").build(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    )
+
+    assert kwargs["custom_llm_provider"] == "hosted_vllm"
+
+
+def test_tools_are_formatted_and_tool_choice_is_forwarded() -> None:
+    kwargs, _ = _builder().build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [
+                {
+                    "name": "lookup",
+                    "description": "Lookup an item",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "lookup"}},
+        }
+    )
+
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Lookup an item",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    assert kwargs["tool_choice"] == {"type": "function", "function": {"name": "lookup"}}
+
+
+def test_openai_tool_schema_is_preserved_and_parallel_tool_calls_can_pass_through() -> None:
+    request = LiteLLMRequestConfig(parallel_tool_calls=True)
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            expected_server_flags={"enable_auto_tool_choice": True, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    kwargs, _ = _builder(litellm_request=request, tool_call_policy=policy).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "description": "Lookup an item",
+                        "parameters": {"type": "object", "properties": {}},
+                        "strict": True,
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+        }
+    )
+
+    assert kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Lookup an item",
+                "parameters": {"type": "object", "properties": {}},
+                "strict": True,
+            },
+        }
+    ]
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+
+
+def test_tool_calling_config_defaults_are_used_when_inputs_omit_them() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            tool_choice="auto",
+            parallel_tool_calls=True,
+            expected_server_flags={"enable_auto_tool_choice": True, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    kwargs, _ = _builder(tool_call_policy=policy).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+        }
+    )
+
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+
+
+def test_tool_calling_inputs_override_config_defaults() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            tool_choice="auto",
+            parallel_tool_calls=True,
+            expected_server_flags={"enable_auto_tool_choice": True, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    kwargs, _ = _builder(tool_call_policy=policy).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            "tool_choice": {"type": "function", "function": {"name": "lookup"}},
+            "parallel_tool_calls": False,
+        }
+    )
+
+    assert kwargs["tool_choice"] == {"type": "function", "function": {"name": "lookup"}}
+    assert kwargs["parallel_tool_calls"] is False
+
+
+def test_auto_tool_choice_requires_expected_server_parser() -> None:
+    with pytest.raises(ValueError, match="tool_parser_missing"):
+        _builder().build(
+            {
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                "tool_choice": "auto",
+            }
+        )
+
+
+def test_auto_tool_choice_requires_enable_auto_tool_choice_flag() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            expected_server_flags={"tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    with pytest.raises(ValueError, match="tool_parser_missing.*enable_auto_tool_choice"):
+        _builder(tool_call_policy=policy).build(
+            {
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                "tool_choice": "auto",
+            }
+        )
+
+
+def test_auto_tool_choice_rejects_false_enable_auto_tool_choice_flag() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            expected_server_flags={"enable_auto_tool_choice": False, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    with pytest.raises(ValueError, match="tool_parser_missing.*enable_auto_tool_choice"):
+        _builder(tool_call_policy=policy).build(
+            {
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+                "tool_choice": "auto",
+            }
+        )
+
+
+def test_hosted_vllm_with_declared_tool_flags_allows_false_static_function_calling_helper() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            expected_server_flags={"enable_auto_tool_choice": True, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    kwargs, _ = _builder(tool_call_policy=policy, supports_function_calling=False).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            "tool_choice": "auto",
+        }
+    )
+
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["tools"][0]["function"]["name"] == "lookup"
+
+
+def test_remote_openai_compatible_with_declared_tool_flags_allows_false_static_helper() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            expected_server_flags={"enable_auto_tool_choice": True, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    kwargs, _ = _builder(
+        model_name="openai/demo-model",
+        provider="openai",
+        custom_llm_provider="openai",
+        api_base="https://vllm.example.com/v1",
+        tool_call_policy=policy,
+        supports_function_calling=False,
+    ).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            "tool_choice": "auto",
+        }
+    )
+
+    assert kwargs["model"] == "openai/demo-model"
+    assert kwargs["api_base"] == "https://vllm.example.com/v1"
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["tools"][0]["function"]["name"] == "lookup"
+
+
+def test_config_auto_tool_choice_does_not_pollute_explicit_named_tool_choice() -> None:
+    policy = ToolCallPolicy(LiteLLMToolCallingConfig(auto_tool_choice=True))
+    named_choice = {"type": "function", "function": {"name": "lookup"}}
+
+    kwargs, _ = _builder(tool_call_policy=policy).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            "tool_choice": named_choice,
+        }
+    )
+
+    assert kwargs["tool_choice"] == named_choice
+
+
+def test_openai_auto_tool_choice_does_not_require_vllm_server_flags() -> None:
+    kwargs, _ = _builder(
+        model_name="openai/gpt-4o-mini",
+        provider="openai",
+        custom_llm_provider="openai",
+        api_base=None,
+        supports_function_calling=True,
+    ).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            "tool_choice": "auto",
+        }
+    )
+
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["tools"][0]["function"]["name"] == "lookup"
+
+
+def test_auto_tool_choice_with_expected_server_flags_parser_builds() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            expected_server_flags={"enable_auto_tool_choice": True, "tool_call_parser": "qwen3_xml"},
+        )
+    )
+
+    kwargs, _ = _builder(tool_call_policy=policy).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            "tool_choice": "auto",
+        }
+    )
+
+    assert kwargs["tool_choice"] == "auto"
+
+
+def test_legacy_expected_tool_parser_satisfies_auto_tool_choice_parser_requirement() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            auto_tool_choice=True,
+            expected_tool_parser="qwen3_xml",
+            expected_server_flags={"enable_auto_tool_choice": True},
+        )
+    )
+
+    kwargs, _ = _builder(tool_call_policy=policy).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+        }
+    )
+
+    assert kwargs["tool_choice"] == "auto"
+
+
+def test_function_calling_not_supported_fails_when_tools_requested() -> None:
+    with pytest.raises(ValueError, match="tool_calling_not_supported"):
+        _builder(supports_function_calling=False).build(
+            {
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            }
+        )
+
+
+def test_unknown_function_calling_support_allows_tools_for_compatibility() -> None:
+    kwargs, _ = _builder(supports_function_calling=None).build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+        }
+    )
+
+    assert kwargs["tools"][0]["function"]["name"] == "lookup"
+
+
+def test_tool_policy_fails_fast_when_required_server_parser_is_missing() -> None:
+    policy = ToolCallPolicy(
+        LiteLLMToolCallingConfig(
+            enabled=True,
+            require_server_parser=True,
+            expected_tool_parser=None,
+        )
+    )
+    builder = _builder(tool_call_policy=policy)
+
+    with pytest.raises(ValueError, match="tool_parser_missing"):
+        builder.build(
+            {
+                "messages": [{"role": "user", "content": "ping"}],
+                "tools": [{"name": "lookup", "parameters": {"type": "object", "properties": {}}}],
+            }
+        )
+
+
+def test_deepseek_model_is_prefixed_for_native_provider() -> None:
+    kwargs, _ = _builder(
+        model_name="deepseek-chat",
+        provider="deepseek",
+        api_base="https://api.deepseek.com",
+        custom_llm_provider="deepseek",
+    ).build({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert kwargs["model"] == "deepseek/deepseek-chat"
+    assert kwargs["custom_llm_provider"] == "deepseek"
+
+
+def test_azure_request_includes_api_type_and_version() -> None:
+    kwargs, _ = _builder(
+        model_name="azure:gpt-4o-mini",
+        provider="azure",
+        api_base="https://demo-openai.eastus.azure.com",
+        custom_llm_provider="azure",
+        is_azure_target=True,
+        azure_api_version="2024-06-01-preview",
+    ).build({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert kwargs["api_type"] == "azure"
+    assert kwargs["api_version"] == "2024-06-01-preview"
+
+
+def test_stop_max_tokens_and_n_are_normalized_from_sampling_params() -> None:
+    kwargs, sampling_params = _builder().build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "sampling_params": {
+                "max_new_tokens": 64,
+                "stop": "END",
+                "n": 3,
+            },
+        }
+    )
+
+    assert sampling_params["max_tokens"] == 64
+    assert sampling_params["stop"] == "END"
+    assert sampling_params["n"] == 3
+    assert kwargs["max_tokens"] == 64
+    assert kwargs["stop"] == ["END"]
+    assert kwargs["n"] == 3
+
+
+def test_all_litellm_request_passthrough_fields_are_whitelisted_and_forwarded() -> None:
+    request_payload = {
+        "response_format": {"type": "json_object"},
+        "max_completion_tokens": 1024,
+        "stream_options": {"include_usage": True},
+        "parallel_tool_calls": False,
+        "logit_bias": {"42": -1},
+        "user": "eval-user",
+        "metadata": {"run_id": "run-001"},
+        "fallbacks": [{"model": "openai/fallback"}],
+        "context_window_fallback_dict": {"openai/large": "openai/small"},
+        "extra_body": {"top_k": 20},
+        "drop_params": False,
+    }
+    request = LiteLLMRequestConfig(**request_payload)
+
+    kwargs, _ = _builder(litellm_request=request).build(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    )
+
+    assert set(LITELLM_REQUEST_PASSTHROUGH_FIELDS) == set(request_payload)
+    for field, value in request_payload.items():
+        assert kwargs[field] == value
+
+
+def test_litellm_request_extra_fields_are_preserved_but_not_forwarded() -> None:
+    request = LiteLLMRequestConfig(foo="bar", extra_body={"top_k": 20})
+
+    kwargs, _ = _builder(litellm_request=request).build(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    )
+
+    assert getattr(request, "foo") == "bar"
+    assert kwargs["extra_body"] == {"top_k": 20}
+    assert "foo" not in kwargs
+
+
+def test_extra_body_passthrough_is_deep_copied() -> None:
+    request = LiteLLMRequestConfig(
+        extra_body={"chat_template_kwargs": {"enable_thinking": False, "nested": {"value": 1}}}
+    )
+
+    kwargs, _ = _builder(litellm_request=request).build(
+        {"messages": [{"role": "user", "content": "ping"}]}
+    )
+    kwargs["extra_body"]["chat_template_kwargs"]["nested"]["value"] = 2
+
+    assert request.extra_body["chat_template_kwargs"]["nested"]["value"] == 1
+
+
+def test_runtime_sampling_unknown_high_risk_fields_are_not_forwarded() -> None:
+    kwargs, _ = _builder().build(
+        {
+            "messages": [{"role": "user", "content": "ping"}],
+            "sampling_params": {
+                "max_new_tokens": 64,
+                "temperature": 0.1,
+                "response_format": {"type": "json_object"},
+                "modalities": ["audio"],
+                "audio": {"voice": "alloy"},
+                "prediction": {"type": "content", "content": "cached"},
+                "foo": "bar",
+            },
+        }
+    )
+
+    assert kwargs["max_tokens"] == 64
+    assert kwargs["temperature"] == 0.1
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert "modalities" not in kwargs
+    assert "audio" not in kwargs
+    assert "prediction" not in kwargs
+    assert "foo" not in kwargs

--- a/tests/unit/role/model/test_litellm_response_normalizer.py
+++ b/tests/unit/role/model/test_litellm_response_normalizer.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.response_normalizer import LiteLLMResponseNormalizer
+
+pytestmark = pytest.mark.fast
+
+
+def test_dict_response_extracts_answer_reasoning_tool_calls_finish_reason_and_usage() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    raw = {
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": "final",
+                    "reasoning_content": "think",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "arguments": "{\"q\":\"x\"}",
+                            },
+                        }
+                    ],
+                    "thinking_blocks": [{"type": "reasoning", "text": "provider block"}],
+                },
+            }
+        ],
+        "usage": {"completion_tokens": 3},
+    }
+
+    result = normalizer.normalize(raw, request_context={"thinking_mode": "auto"})
+
+    assert result["answer"] == "final"
+    assert result["raw_response"] == raw
+    assert result["usage"] == {"completion_tokens": 3}
+    assert result["reasoning_content"] == "think"
+    assert result["finish_reason"] == "tool_calls"
+    assert result["tool_calls"] == [
+        {
+            "id": "call_1",
+            "type": "function",
+            "name": "lookup",
+            "arguments": {"q": "x"},
+            "raw_arguments": "{\"q\":\"x\"}",
+        }
+    ]
+    assert result["metadata"]["thinking_effective"] == "enabled"
+    assert result["metadata"]["thinking_blocks"] == [{"type": "reasoning", "text": "provider block"}]
+
+
+def test_object_response_field_extraction_does_not_depend_on_dict_only() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    message = types.SimpleNamespace(
+        content=[{"type": "text", "text": "hel"}, {"type": "text", "text": "lo"}],
+        reasoning_details=[{"type": "text", "text": "object think"}],
+        tool_calls=[
+            types.SimpleNamespace(
+                id="call_obj",
+                type="function",
+                function=types.SimpleNamespace(name="lookup", arguments="{\"q\":\"object\"}"),
+            )
+        ],
+    )
+    raw = types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message=message, finish_reason="stop")],
+        usage=types.SimpleNamespace(total_tokens=7),
+    )
+
+    result = normalizer.normalize(raw, request_context={"thinking_mode": "auto"})
+
+    assert result["answer"] == "hello"
+    assert result["raw_response"]["usage"] == {"total_tokens": 7}
+    assert result["usage"] == {"total_tokens": 7}
+    assert result["reasoning_content"] == "object think"
+    assert result["tool_calls"][0]["arguments"] == {"q": "object"}
+    assert result["finish_reason"] == "stop"
+
+
+def test_reasoning_content_and_reasoning_details_are_both_preserved() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    reasoning_details = [{"type": "summary", "text": "detail trace"}]
+    raw = {
+        "choices": [
+            {
+                "message": {
+                    "content": "final",
+                    "reasoning_content": "structured trace",
+                    "reasoning_details": reasoning_details,
+                }
+            }
+        ]
+    }
+
+    result = normalizer.normalize(raw, request_context={"thinking_mode": "auto"})
+
+    assert result["reasoning_content"] == "structured trace"
+    assert result["reasoning_details"] == reasoning_details
+    assert result["metadata"]["reasoning_source"] == "reasoning_content"
+    assert result["metadata"]["thinking_effective"] == "enabled"
+
+
+def test_think_tag_fallback_extracts_reasoning_and_cleans_answer() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+
+    result = normalizer.normalize(
+        {"choices": [{"message": {"content": "<think>hidden</think>\nvisible"}}]},
+        request_context={"thinking_mode": "auto"},
+    )
+
+    assert result["answer"] == "visible"
+    assert result["reasoning_content"] == "hidden"
+    assert result["metadata"]["reasoning_source"] == "think_tags"
+
+
+def test_invalid_tool_arguments_are_preserved_without_raising() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    raw = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_bad",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{bad-json"},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    result = normalizer.normalize(raw, request_context={})
+
+    tool_call = result["tool_calls"][0]
+    assert tool_call["name"] == "lookup"
+    assert tool_call["arguments"] is None
+    assert tool_call["raw_arguments"] == "{bad-json"
+    assert tool_call["error"] == "invalid_tool_arguments"
+
+
+def test_stream_chunks_aggregate_answer_usage_finish_reason_and_tool_delta() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    chunks = [
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "fin",
+                        "reasoning_content": "th",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_stream",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{\"q\""},
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "al",
+                        "reasoning_content": "ink",
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"arguments": ":\"x\"}"},
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"completion_tokens": 3},
+        },
+    ]
+
+    result = normalizer.normalize_stream(chunks, request_context={"thinking_mode": "auto"})
+
+    assert result["answer"] == "final"
+    assert result["reasoning_content"] == "think"
+    assert result["usage"] == {"completion_tokens": 3}
+    assert result["finish_reason"] == "tool_calls"
+    assert result["tool_calls"][0]["arguments"] == {"q": "x"}
+    assert result["tool_calls"][0]["raw_arguments"] == "{\"q\":\"x\"}"
+
+
+def test_stream_chunks_preserve_reasoning_details() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    chunks = [
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "a",
+                        "reasoning_details": [{"type": "text", "text": "first"}],
+                    }
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "b",
+                        "reasoning_details": [{"type": "text", "text": "second"}],
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+    ]
+
+    result = normalizer.normalize_stream(chunks, request_context={"thinking_mode": "auto"})
+
+    assert result["answer"] == "ab"
+    assert result["reasoning_content"] == "firstsecond"
+    assert result["reasoning_details"] == [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "second"},
+    ]
+    assert result["metadata"]["thinking_effective"] == "enabled"
+
+
+def test_thinking_mismatch_metadata_and_fail_fast() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    raw = {"choices": [{"message": {"content": "final", "reasoning_content": "think"}}]}
+
+    result = normalizer.normalize(
+        raw,
+        request_context={
+            "thinking_mode": "disabled",
+            "thinking_policy": {"on_mismatch": "warn_and_continue"},
+        },
+    )
+
+    assert result["metadata"]["thinking_effective"] == "enabled"
+    assert result["metadata"]["thinking_mismatch"]["expected"] == "disabled"
+    assert result["metadata"]["thinking_mismatch"]["observed"] == "enabled"
+
+    with pytest.raises(ValueError, match="response_mismatch"):
+        normalizer.normalize(
+            raw,
+            request_context={
+                "thinking_mode": "disabled",
+                "thinking_policy": {"on_mismatch": "fail_fast"},
+            },
+        )
+
+
+def test_usage_reasoning_tokens_trigger_thinking_mismatch_when_disabled() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    raw = {
+        "choices": [{"message": {"content": "final"}}],
+        "usage": {
+            "completion_tokens": 5,
+            "completion_tokens_details": {"reasoning_tokens": 2},
+        },
+    }
+
+    result = normalizer.normalize(
+        raw,
+        request_context={
+            "thinking_mode": "disabled",
+            "thinking_policy": {"on_mismatch": "warn_and_continue"},
+        },
+    )
+
+    assert result["metadata"]["thinking_effective"] == "enabled"
+    assert result["metadata"]["thinking_mismatch"]["expected"] == "disabled"
+    assert result["metadata"]["thinking_mismatch"]["observed"] == "enabled"
+
+
+def test_unreadable_reasoning_details_still_trigger_thinking_mismatch_when_disabled() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    raw = {
+        "choices": [
+            {
+                "message": {
+                    "content": "final",
+                    "reasoning_details": [{"type": "encrypted", "payload": {"bytes": 128}}],
+                }
+            }
+        ]
+    }
+
+    result = normalizer.normalize(
+        raw,
+        request_context={
+            "thinking_mode": "disabled",
+            "thinking_policy": {"on_mismatch": "warn_and_continue"},
+        },
+    )
+
+    assert result["reasoning_content"] is None
+    assert result["reasoning_details"] == [{"type": "encrypted", "payload": {"bytes": 128}}]
+    assert result["metadata"]["thinking_effective"] == "enabled"
+    assert result["metadata"]["thinking_mismatch"]["reasoning_source"] == "reasoning_details"
+
+
+def test_enabled_thinking_with_tool_calls_records_missing_thinking_blocks_without_reasoning_text() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    raw = {
+        "choices": [
+            {
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{\"q\":\"x\"}"},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+    result = normalizer.normalize(raw, request_context={"thinking_mode": "enabled"})
+
+    assert result["tool_calls"][0]["name"] == "lookup"
+    assert result["metadata"]["thinking_blocks_missing"] is True
+
+
+def test_observation_summary_redacts_sensitive_payloads_and_records_counts() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    large_args = "{\"secret\":\"" + ("x" * 2000) + "\"}"
+    request_kwargs = {
+        "model": "hosted_vllm/demo",
+        "api_base": "http://127.0.0.1:8000/v1",
+        "base_url": "http://127.0.0.1:8000/v1",
+        "api_key": "sk-secret-value",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                    {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,BBBB"}},
+                ],
+            }
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "lookup", "arguments": large_args},
+            }
+        ],
+        "parallel_tool_calls": False,
+    }
+    result = {
+        "finish_reason": "stop",
+        "usage": {"total_tokens": 10},
+        "latency_ms": 12.3456,
+        "metadata": {"thinking_effective": "disabled"},
+        "tool_calls": [{"id": "call_secret", "name": "lookup", "raw_arguments": large_args}],
+    }
+
+    summary = normalizer.build_observation_summary(
+        request_kwargs,
+        result,
+        request_context={
+            "provider": "hosted_vllm",
+            "route_mode": "router",
+            "topology": {"kind": "local_8gpu", "replicas": 8},
+            "thinking_mode": "disabled",
+            "retry_owner": "gateway",
+        },
+    )
+    rendered = repr(summary)
+
+    assert "sk-secret-value" not in rendered
+    assert "base64,AAAA" not in rendered
+    assert "call_secret" not in rendered
+    assert "x" * 200 not in rendered
+    assert summary["provider"] == "hosted_vllm"
+    assert summary["model"] == "hosted_vllm/demo"
+    assert summary["api_base_hash"]
+    assert summary["route_mode"] == "router"
+    assert summary["topology"]["kind"] == "local_8gpu"
+    assert summary["modality_counts"]["text"] == 1
+    assert summary["modality_counts"]["image"] == 1
+    assert summary["modality_counts"]["audio"] == 1
+    assert summary["tool_count"] == 1
+    assert summary["tool_call_count"] == 1
+    assert summary["resolved_thinking_mode"] == "disabled"
+    assert summary["effective_thinking_mode"] == "disabled"
+    assert summary["usage"] == {"total_tokens": 10}
+    assert summary["latency_ms"] == 12.346
+
+
+def test_observation_summary_sanitizes_sensitive_usage_payloads() -> None:
+    normalizer = LiteLLMResponseNormalizer()
+    secret_key = "sk-usage-secret"
+    data_url = "data:image/png;base64," + ("A" * 300)
+    debug_payload = "debug-" + ("x" * 300)
+
+    summary = normalizer.build_observation_summary(
+        {"model": "hosted_vllm/demo", "api_base": "http://127.0.0.1:8000/v1"},
+        {
+            "finish_reason": "stop",
+            "usage": {
+                "total_tokens": 10,
+                "api_key": secret_key,
+                "debug": debug_payload,
+                "nested": {"payload": data_url},
+            },
+            "metadata": {"thinking_effective": "disabled"},
+        },
+        request_context={"provider": "hosted_vllm"},
+    )
+    rendered = repr(summary)
+
+    assert secret_key not in rendered
+    assert data_url not in rendered
+    assert debug_payload not in rendered
+    assert summary["usage"]["total_tokens"] == 10
+    assert summary["usage"]["api_key"] == "[REDACTED]"
+    assert summary["usage"]["debug"]["chars"] == len(debug_payload)
+    assert summary["usage"]["nested"]["payload"]["kind"] == "data_url"

--- a/tests/unit/role/model/test_litellm_router_factory.py
+++ b/tests/unit/role/model/test_litellm_router_factory.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from gage_eval.role.model.backends.litellm_backend import LiteLLMBackend
+from gage_eval.role.model.config.litellm import LiteLLMBackendConfig
+
+pytestmark = pytest.mark.fast
+
+
+class FakeRouter:
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.calls = []
+
+    def completion(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "router-ok"}}]}
+
+
+class FakeLiteLLM(types.SimpleNamespace):
+    def __init__(self):
+        super().__init__(Router=FakeRouter)
+        self.calls = []
+        self.verbose = False
+
+    def completion(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        return {"choices": [{"message": {"content": "direct-ok"}}]}
+
+    def supports_reasoning(self, _model):
+        return False
+
+
+def test_router_factory_builds_router_from_gage_model_list() -> None:
+    from gage_eval.role.model.backends.litellm.router_factory import LiteLLMRouterFactory
+
+    fake_litellm = FakeLiteLLM()
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                        "api_key": "dummy",
+                    },
+                    "rpm": 60,
+                }
+            ],
+            "router_settings": {
+                "routing_strategy": "simple-shuffle",
+                "allowed_fails": 3,
+                "cooldown_time": 30,
+                "num_retries": 2,
+                "retry_after": 5,
+            },
+        }
+    )
+
+    router = LiteLLMRouterFactory(fake_litellm).build(cfg)
+
+    assert isinstance(router, FakeRouter)
+    assert router.init_kwargs["model_list"][0]["model_name"] == "qwen3-group"
+    assert router.init_kwargs["model_list"][0]["litellm_params"]["api_base"] == "http://127.0.0.1:8000/v1"
+    assert router.init_kwargs["model_list"][0]["rpm"] == 60
+    assert router.init_kwargs["routing_strategy"] == "simple-shuffle"
+    assert router.init_kwargs["allowed_fails"] == 3
+    assert router.init_kwargs["cooldown_time"] == 30
+    assert router.init_kwargs["num_retries"] == 2
+    assert router.init_kwargs["retry_after"] == 5
+
+
+def test_router_factory_direct_without_model_list_returns_none() -> None:
+    from gage_eval.role.model.backends.litellm.router_factory import LiteLLMRouterFactory
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "openai/qwen3-gateway",
+            "api_base": "http://127.0.0.1:4000/v1",
+            "api_key": "dummy",
+        }
+    )
+
+    assert LiteLLMRouterFactory(FakeLiteLLM()).build(cfg) is None
+
+
+def test_router_factory_explicit_direct_with_model_list_returns_none() -> None:
+    from gage_eval.role.model.backends.litellm.router_factory import LiteLLMRouterFactory
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "route_mode": "direct",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                        "api_key": "deployment-key",
+                    },
+                }
+            ],
+        }
+    )
+
+    assert LiteLLMRouterFactory(FakeLiteLLM()).build(cfg) is None
+
+
+def test_router_factory_fails_fast_when_router_mode_has_empty_model_list() -> None:
+    from gage_eval.role.model.backends.litellm.router_factory import LiteLLMRouterFactory
+
+    cfg = LiteLLMBackendConfig.model_validate({"model": "qwen3-group", "route_mode": "router"})
+
+    with pytest.raises(ValueError, match="model_list"):
+        LiteLLMRouterFactory(FakeLiteLLM()).build(cfg)
+
+
+def test_service_profile_warns_when_single_profile_applies_to_all_deployments() -> None:
+    from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3-a",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                    },
+                },
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3-b",
+                        "api_base": "http://127.0.0.1:8001/v1",
+                    },
+                },
+            ],
+            "vllm": {"reasoning_parser": "qwen3"},
+        }
+    )
+
+    warnings = VLLMServiceProfile.from_config(cfg).validate_deployment_consistency()
+
+    assert warnings == [
+        "per-deployment vLLM metadata not provided; assuming declared profile applies to all deployments"
+    ]
+
+
+def test_service_profile_warns_when_top_level_language_model_only_lacks_deployment_metadata() -> None:
+    from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-a"},
+                },
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-b"},
+                },
+            ],
+            "vllm": {"topology": {"language_model_only": True}},
+        }
+    )
+
+    warnings = VLLMServiceProfile.from_config(cfg).validate_deployment_consistency()
+
+    assert warnings == [
+        "per-deployment vLLM metadata not provided; assuming declared profile applies to all deployments"
+    ]
+
+
+def test_service_profile_fails_on_inconsistent_per_deployment_reasoning_parser() -> None:
+    from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-a"},
+                    "vllm": {"reasoning_parser": "qwen3"},
+                },
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-b"},
+                    "vllm": {"reasoning_parser": "deepseek-r1"},
+                },
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="reasoning_parser"):
+        VLLMServiceProfile.from_config(cfg).validate_deployment_consistency()
+
+
+def test_service_profile_fails_on_inconsistent_per_deployment_chat_template_defaults() -> None:
+    from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-a"},
+                    "vllm": {"chat_template_defaults": {"enable_thinking": True}},
+                },
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-b"},
+                    "vllm": {"chat_template_defaults": {"enable_thinking": False}},
+                },
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="chat_template_defaults"):
+        VLLMServiceProfile.from_config(cfg).validate_deployment_consistency()
+
+
+def test_service_profile_fails_on_inconsistent_per_deployment_language_model_only() -> None:
+    from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+
+    cfg = LiteLLMBackendConfig.model_validate(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-a"},
+                    "vllm": {"topology": {"language_model_only": True}},
+                },
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {"model": "hosted_vllm/qwen3-b"},
+                    "language_model_only": False,
+                },
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="language_model_only"):
+        VLLMServiceProfile.from_config(cfg).validate_deployment_consistency()
+
+
+def test_backend_router_mode_calls_router_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "qwen3-group",
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                        "api_key": "dummy",
+                    },
+                }
+            ],
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "router-ok"
+    assert fake_litellm.calls == []
+    assert isinstance(backend._router, FakeRouter)
+    assert backend._router.calls[0]["model"] == "qwen3-group"
+    assert backend._router.calls[0]["messages"] == [{"role": "user", "content": "ping"}]
+
+
+def test_backend_router_completion_does_not_forward_direct_transport_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "qwen3-group",
+            "api_base": "http://wrong-top-level.example/v1",
+            "api_key": "wrong-top-level-key",
+            "custom_llm_provider": "openai",
+            "extra_headers": {"X-Wrong": "top-level"},
+            "model_list": [
+                {
+                    "model_name": "qwen3-group",
+                    "litellm_params": {
+                        "model": "hosted_vllm/qwen3-a",
+                        "api_base": "http://127.0.0.1:8000/v1",
+                        "api_key": "deployment-key-a",
+                    },
+                }
+            ],
+            "generation_parameters": {"max_new_tokens": 16, "temperature": 0.2},
+            "timeout": 30,
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "router-ok"
+    call = backend._router.calls[0]
+    assert call["model"] == "qwen3-group"
+    assert call["messages"] == [{"role": "user", "content": "ping"}]
+    assert call["max_tokens"] == 16
+    assert call["temperature"] == 0.2
+    assert call["timeout"] == 30
+    assert "api_base" not in call
+    assert "base_url" not in call
+    assert "api_key" not in call
+    assert "custom_llm_provider" not in call
+    assert "api_type" not in call
+    assert "api_version" not in call
+    assert "headers" not in call
+
+
+def test_backend_gateway_without_model_list_stays_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_litellm = FakeLiteLLM()
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+
+    backend = LiteLLMBackend(
+        {
+            "model": "openai/qwen3-gateway",
+            "api_base": "http://127.0.0.1:4000/v1",
+            "api_key": "dummy",
+            "generation_parameters": {"max_new_tokens": 16},
+        }
+    )
+
+    result = backend.generate({"messages": [{"role": "user", "content": "ping"}]})
+
+    assert result["answer"] == "direct-ok"
+    assert backend._router is None
+    assert len(fake_litellm.calls) == 1
+    assert fake_litellm.calls[0]["api_base"] == "http://127.0.0.1:4000/v1"

--- a/tests/unit/role/model/test_litellm_thinking_policy.py
+++ b/tests/unit/role/model/test_litellm_thinking_policy.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import pytest
+
+from gage_eval.role.model.backends.litellm.policies import ThinkingControlPolicy
+from gage_eval.role.model.backends.litellm.request_builder import LiteLLMRequestBuilder
+from gage_eval.role.model.backends.litellm.service_profile import VLLMServiceProfile
+from gage_eval.role.model.config.litellm import LiteLLMRequestConfig
+
+pytestmark = pytest.mark.fast
+
+
+def _profile(reasoning_parser: str | None = "qwen3") -> VLLMServiceProfile:
+    return VLLMServiceProfile(
+        mode="direct",
+        model="hosted_vllm/Qwen/Qwen3-8B",
+        api_base="http://127.0.0.1:8000/v1",
+        reasoning_parser=reasoning_parser,
+    )
+
+
+def _builder(**overrides: object) -> LiteLLMRequestBuilder:
+    params = {
+        "model_name": "hosted_vllm/Qwen/Qwen3-8B",
+        "provider": "hosted_vllm",
+        "api_base": "http://127.0.0.1:8000/v1",
+        "api_key": "dummy",
+        "custom_llm_provider": "hosted_vllm",
+        "base_sampling": {"max_new_tokens": 128},
+        "litellm_request": LiteLLMRequestConfig(),
+        "drop_params": True,
+        "supports_reasoning": False,
+        "max_context_length": None,
+        "thinking_policy": ThinkingControlPolicy(service_profile=_profile()),
+    }
+    params.update(overrides)
+    return LiteLLMRequestBuilder(**params)
+
+
+def _messages() -> dict:
+    return {"messages": [{"role": "user", "content": "solve 2+2"}]}
+
+
+def test_qwen3_vllm_disabled_uses_extra_body_not_top_level() -> None:
+    kwargs, _ = _builder().build(_messages(), thinking_config={"thinking_mode": "disabled"})
+
+    assert "enable_thinking" not in kwargs
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_qwen3_vllm_enabled_uses_extra_body_true() -> None:
+    kwargs, _ = _builder().build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert "enable_thinking" not in kwargs
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_thinking_mode_none_does_not_inject_enable_thinking() -> None:
+    kwargs, _ = _builder().build(_messages(), thinking_config={"thinking_mode": None})
+
+    assert "enable_thinking" not in kwargs
+    assert "extra_body" not in kwargs or "enable_thinking" not in kwargs["extra_body"].get("chat_template_kwargs", {})
+
+
+def test_reasoning_effort_remains_top_level_litellm_kwarg() -> None:
+    kwargs, _ = _builder().build(
+        {
+            "messages": [{"role": "user", "content": "think hard"}],
+            "sampling_params": {"reasoning_effort": "high"},
+        },
+        thinking_config={"thinking_mode": "auto"},
+    )
+
+    assert kwargs["reasoning_effort"] == "high"
+
+
+def test_disabled_thinking_with_reasoning_model_does_not_expand_max_tokens() -> None:
+    kwargs, _ = _builder(supports_reasoning=True).build(
+        {
+            "messages": [{"role": "user", "content": "short answer"}],
+            "sampling_params": {"max_new_tokens": 128},
+        },
+        thinking_config={"thinking_mode": "disabled"},
+    )
+
+    assert kwargs["max_tokens"] == 128
+
+
+def test_enabled_thinking_with_reasoning_model_may_expand_max_tokens() -> None:
+    kwargs, _ = _builder(supports_reasoning=True, max_context_length=1000).build(
+        {
+            "messages": [{"role": "user", "content": "show reasoning"}],
+            "sampling_params": {"max_new_tokens": 128},
+        },
+        thinking_config={"thinking_mode": "enabled"},
+    )
+
+    assert kwargs["max_tokens"] == 1000
+
+
+def test_enabled_vllm_without_reasoning_parser_fail_fast_raises() -> None:
+    policy = ThinkingControlPolicy(service_profile=_profile(reasoning_parser=None), on_unsupported="fail_fast")
+
+    with pytest.raises(ValueError, match="thinking.*reasoning_parser"):
+        policy.resolve(
+            model="hosted_vllm/Qwen/Qwen3-8B",
+            provider="hosted_vllm",
+            custom_llm_provider="hosted_vllm",
+            thinking_config={"thinking_mode": "enabled"},
+        )
+
+
+def test_enabled_vllm_without_reasoning_parser_default_warns_but_builds() -> None:
+    builder = _builder(thinking_policy=ThinkingControlPolicy(service_profile=_profile(reasoning_parser=None)))
+
+    kwargs, _ = builder.build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_capability_unsupported_enabled_fail_fast_raises() -> None:
+    policy = ThinkingControlPolicy(
+        service_profile=_profile(),
+        capability="unsupported",
+        on_unsupported="fail_fast",
+    )
+
+    with pytest.raises(ValueError, match="thinking.*unsupported"):
+        policy.resolve(
+            model="hosted_vllm/Qwen/Qwen3-8B",
+            provider="hosted_vllm",
+            custom_llm_provider="hosted_vllm",
+            thinking_config={"thinking_mode": "enabled"},
+        )
+
+
+def test_capability_unsupported_enabled_default_builds_without_vllm_enable_thinking() -> None:
+    builder = _builder(thinking_policy=ThinkingControlPolicy(service_profile=_profile(), capability="unsupported"))
+
+    kwargs, _ = builder.build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert "extra_body" not in kwargs or "enable_thinking" not in kwargs["extra_body"].get("chat_template_kwargs", {})
+
+
+def test_capability_supported_hosted_vllm_enabled_without_parser_injects_without_fail_fast() -> None:
+    builder = _builder(
+        thinking_policy=ThinkingControlPolicy(
+            service_profile=_profile(reasoning_parser=None),
+            capability="supported",
+            on_unsupported="fail_fast",
+        )
+    )
+
+    kwargs, _ = builder.build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_explicit_litellm_request_extra_body_overrides_policy_enable_thinking() -> None:
+    request = LiteLLMRequestConfig(extra_body={"chat_template_kwargs": {"enable_thinking": False}})
+
+    kwargs, _ = _builder(litellm_request=request).build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_explicit_litellm_request_disable_controls_reasoning_max_tokens() -> None:
+    request = LiteLLMRequestConfig(extra_body={"chat_template_kwargs": {"enable_thinking": False}})
+
+    kwargs, _ = _builder(litellm_request=request, supports_reasoning=True).build(
+        {
+            "messages": [{"role": "user", "content": "short answer"}],
+            "sampling_params": {"max_new_tokens": 128},
+        },
+        thinking_config={"thinking_mode": "enabled"},
+    )
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+    assert kwargs["max_tokens"] == 128
+
+
+def test_explicit_litellm_request_enable_controls_reasoning_max_tokens() -> None:
+    request = LiteLLMRequestConfig(extra_body={"chat_template_kwargs": {"enable_thinking": True}})
+
+    kwargs, _ = _builder(litellm_request=request, supports_reasoning=True, max_context_length=1000).build(
+        {
+            "messages": [{"role": "user", "content": "show reasoning"}],
+            "sampling_params": {"max_new_tokens": 128},
+        },
+        thinking_config={"thinking_mode": "disabled"},
+    )
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+    assert kwargs["max_tokens"] == 1000
+
+
+def test_runtime_extra_body_disable_controls_reasoning_max_tokens() -> None:
+    kwargs, _ = _builder(supports_reasoning=True).build(
+        {
+            "messages": [{"role": "user", "content": "short answer"}],
+            "sampling_params": {
+                "max_new_tokens": 128,
+                "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+            },
+        },
+        thinking_config={"thinking_mode": "enabled"},
+    )
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+    assert kwargs["max_tokens"] == 128
+
+
+def test_runtime_extra_body_enable_controls_reasoning_max_tokens() -> None:
+    kwargs, _ = _builder(supports_reasoning=True, max_context_length=1000).build(
+        {
+            "messages": [{"role": "user", "content": "show reasoning"}],
+            "sampling_params": {
+                "max_new_tokens": 128,
+                "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+            },
+        },
+        thinking_config={"thinking_mode": "disabled"},
+    )
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+    assert kwargs["max_tokens"] == 1000
+
+
+def test_openai_provider_with_openai_api_base_does_not_inject_vllm_extra_body() -> None:
+    kwargs, _ = _builder(
+        model_name="gpt-4o-mini",
+        provider="openai",
+        custom_llm_provider="openai",
+        api_base="https://api.openai.com/v1",
+        thinking_policy=ThinkingControlPolicy(service_profile=_profile(reasoning_parser="qwen3")),
+    ).build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert "extra_body" not in kwargs
+
+
+def test_openai_provider_with_local_api_base_uses_profile_parser_as_vllm_signal() -> None:
+    kwargs, _ = _builder(
+        model_name="Qwen/Qwen3-8B",
+        provider="openai",
+        custom_llm_provider="openai",
+        api_base="http://127.0.0.1:4000/v1",
+        thinking_policy=ThinkingControlPolicy(service_profile=_profile(reasoning_parser="qwen3")),
+    ).build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_openai_api_base_without_provider_does_not_use_profile_parser_as_vllm_signal() -> None:
+    kwargs, _ = _builder(
+        model_name="gpt-4o-mini",
+        provider=None,
+        custom_llm_provider=None,
+        api_base="https://api.openai.com/v1",
+        thinking_policy=ThinkingControlPolicy(service_profile=_profile(reasoning_parser="qwen3")),
+    ).build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert "extra_body" not in kwargs
+
+
+def test_azure_openai_api_base_without_provider_does_not_use_profile_parser_as_vllm_signal() -> None:
+    kwargs, _ = _builder(
+        model_name="gpt-4o-mini",
+        provider=None,
+        custom_llm_provider=None,
+        api_base="https://demo.openai.azure.com/openai/deployments/gpt-4o",
+        thinking_policy=ThinkingControlPolicy(service_profile=_profile(reasoning_parser="qwen3")),
+    ).build(_messages(), thinking_config={"thinking_mode": "enabled"})
+
+    assert "extra_body" not in kwargs
+
+
+def test_runtime_sampling_thinking_mode_overrides_backend_thinking_config() -> None:
+    kwargs, _ = _builder().build(
+        {
+            "messages": [{"role": "user", "content": "short answer"}],
+            "sampling_params": {"thinking_mode": "disabled"},
+        },
+        thinking_config={"thinking_mode": "enabled"},
+    )
+
+    assert kwargs["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False


### PR DESCRIPTION
* feat(litellm): expand vLLM backend capabilities

Add LiteLLM request building, routing, provider credential isolation, multimodal normalization, thinking/tool policies, response normalization, and experimental model server lifecycle support.

Bump LiteLLM/vLLM dependency floors and cover the new behavior with unit and offline compatibility tests.

* docs(litellm): add backend enhancement guide